### PR TITLE
HTML Tokenisation: DOCTYPE public/system

### DIFF
--- a/html/parser/crashtests/doctype_public.html
+++ b/html/parser/crashtests/doctype_public.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<!DOCTYPE math PUBLIC "-//W3C//DTD MathML 2.0//EN" "http://www.w3.org/Math/DTD/mathml2/mathml2.dtd">
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1 Basic//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11-basic.dtd">
+<!DOCTYPE svg:svg PUBLIC "-//W3C//DTD XHTML 1.1 plus MathML 2.0 plus SVG 1.1//EN" "http://www.w3.org/2002/04/xhtml-math-svg/xhtml-math-svg.dtd">

--- a/html/parser/error.rs
+++ b/html/parser/error.rs
@@ -152,11 +152,18 @@ pub enum HTMLParserError {
 
     /// Cette erreur se produit si l'analyseur syntaxique rencontre un
     /// point de code U+003E (>) où le début de l'identifiant public
-    /// DOCTYPE est attendu (par exemple, <!DOCTYPE html PUBLIC >). Dans
+    /// DOCTYPE est attendu (par exemple, `<!DOCTYPE html PUBLIC >`). Dans
     /// un tel cas, si le DOCTYPE est correctement placé comme préambule
     /// du document, l'analyseur syntaxique place le document en mode
     /// quirks.
     MissingDOCTYPEPublicIdentifier,
+
+    /// Cette erreur se produit si l'analyseur rencontre un point de code
+    /// U+003E (>) où le début de l'identificateur de système DOCTYPE est
+    /// attendu (par exemple, `<!DOCTYPE html SYSTEM >`). Dans un tel cas,
+    /// si le DOCTYPE est correctement placé comme préambule du document,
+    /// l'analyseur syntaxique place le document en mode quirks.
+    MissingDOCTYPESystemIdentifier,
 
     /// Cette erreur se produit si l'analyseur rencontre un point de code
     /// U+003E (>) là où un nom de balise de fin est attendu, c'est-à-dire
@@ -186,6 +193,12 @@ pub enum HTMLParserError {
     /// pas séparés par un espace ASCII. Dans ce cas, l'analyseur se
     /// comporte comme si un espace ASCII était présent.
     MissingWhitespaceAfterDOCTYPEPublicKeyword,
+
+    /// Cette erreur se produit si l'analyseur syntaxique rencontre un
+    /// DOCTYPE dont le mot-clé "SYSTEM" et l'identificateur de système ne
+    /// sont pas séparés par un espace ASCII. Dans ce cas, l'analyseur se
+    /// comporte comme si un espace ASCII était présent.
+    MissingWhitespaceAfterDOCTYPESystemKeyword,
 
     /// Cette erreur se produit si l'analyseur syntaxique rencontre un
     /// DOCTYPE dont le mot clé "DOCTYPE" et le nom ne sont pas séparés
@@ -329,9 +342,13 @@ impl fmt::Display for HTMLParserError {
                     "missing-quote-before-doctype-system-identifier",
                 | Self::MissingDOCTYPEPublicIdentifier =>
                     "missing-doctype-public-identifier",
+                | Self::MissingDOCTYPESystemIdentifier =>
+                    "missing-doctype-system-identifier",
                 | Self::MissingEndTagName => "missing-end-tag-name",
                 | Self::MissingWhitespaceAfterDOCTYPEPublicKeyword =>
                     "missing-whitespace-after-doctype-public-keyword",
+                | Self::MissingWhitespaceAfterDOCTYPESystemKeyword =>
+                    "missing-whitespace-after-doctype-system-keyword",
                 | Self::MissingWhitespaceBeforeDOCTYPEName =>
                     "missing-whitespace-before-doctype-name",
                 | Self::MissingWhitespaceBetweenAttributes =>

--- a/html/parser/error.rs
+++ b/html/parser/error.rs
@@ -135,11 +135,34 @@ pub enum HTMLParserError {
     /// quirks.
     MissingDOCTYPEName,
 
+    /// Cette erreur se produit si l'analyseur syntaxique rencontre un
+    /// point de code U+003E (>) où le début de l'identifiant public
+    /// DOCTYPE est attendu (par exemple, <!DOCTYPE html PUBLIC >). Dans
+    /// un tel cas, si le DOCTYPE est correctement placé comme préambule
+    /// du document, l'analyseur syntaxique place le document en mode
+    /// quirks.
+    MissingDOCTYPEPublicIdentifier,
+
     /// Cette erreur se produit si l'analyseur rencontre un point de code
     /// U+003E (>) là où un nom de balise de fin est attendu, c'est-à-dire
     /// </>. L'analyseur syntaxique ignore l'ensemble de la séquence de
     /// points de code "</>".
     MissingEndTagName,
+
+    /// Cette erreur se produit si l'analyseur syntaxique rencontre
+    /// l'identificateur public DOCTYPE qui n'est pas précédé d'une
+    /// citation (par exemple, `<!DOCTYPE html PUBLIC -//W3C//DTD HTML
+    /// 4.01//EN">`). Dans un tel cas, l'analyseur syntaxique ignore
+    /// l'identificateur public et, si le DOCTYPE est correctement placé
+    /// en tant que préambule du document, place le document en mode
+    /// quirks.
+    MissingQuoteBeforeDOCTYPEPublicIdentifier,
+
+    /// Cette erreur se produit si l'analyseur syntaxique rencontre un
+    /// DOCTYPE dont le mot clé "PUBLIC" et l'identifiant public ne sont
+    /// pas séparés par un espace ASCII. Dans ce cas, l'analyseur se
+    /// comporte comme si un espace ASCII était présent.
+    MissingWhitespaceAfterDOCTYPEPublicKeyword,
 
     /// Cette erreur se produit si l'analyseur syntaxique rencontre un
     /// DOCTYPE dont le mot clé "DOCTYPE" et le nom ne sont pas séparés
@@ -261,7 +284,13 @@ impl fmt::Display for HTMLParserError {
                     "invalid-first-character-of-tag-name",
                 | Self::MissingAttributeValue => "missing-attribute-value",
                 | Self::MissingDOCTYPEName => "missing-doctype-name",
+                | Self::MissingQuoteBeforeDOCTYPEPublicIdentifier =>
+                    "missing-quote-before-doctype-public-identifier",
+                | Self::MissingDOCTYPEPublicIdentifier =>
+                    "missing-doctype-public-identifier",
                 | Self::MissingEndTagName => "missing-end-tag-name",
+                | Self::MissingWhitespaceAfterDOCTYPEPublicKeyword =>
+                    "missing-whitespace-after-doctype-public-keyword",
                 | Self::MissingWhitespaceBeforeDOCTYPEName =>
                     "missing-whitespace-before-doctype-name",
                 | Self::MissingWhitespaceBetweenAttributes =>

--- a/html/parser/error.rs
+++ b/html/parser/error.rs
@@ -58,6 +58,14 @@ pub enum HTMLParserError {
     /// l'analyseur syntaxique place le document en mode quirks.
     AbruptDOCTYPEPublicIdentifier,
 
+    /// Cette erreur se produit si l'analyseur syntaxique rencontre un
+    /// point de code U+003E (>) dans l'identifiant système DOCTYPE (par
+    /// exemple, `<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN"
+    /// "foo>`). Dans ce cas, si le DOCTYPE est correctement placé
+    /// comme préambule du document, l'analyseur syntaxique place le
+    /// document en mode quirks.
+    AbruptDOCTYPESystemIdentifier,
+
     /// Cette erreur se produit si l'analyseur rencontre une section CDATA
     /// en dehors d'un contenu étranger (SVG ou MathML). L'analyseur
     /// syntaxique traite ces sections CDATA (y compris les chaînes de
@@ -295,6 +303,8 @@ impl fmt::Display for HTMLParserError {
             match self {
                 | Self::AbruptDOCTYPEPublicIdentifier =>
                     "abrupt-doctype-public-identifier",
+                | Self::AbruptDOCTYPESystemIdentifier =>
+                    "abrupt-doctype-system-identifier",
                 | Self::CDATAInHtmlContent => "cdata-in-html-content",
                 | Self::EofBeforeTagName => "eof-before-tag-name",
                 | Self::EofInDOCTYPE => "eof-in-doctype",

--- a/html/parser/error.rs
+++ b/html/parser/error.rs
@@ -165,6 +165,14 @@ pub enum HTMLParserError {
     /// quirks.
     MissingQuoteBeforeDOCTYPEPublicIdentifier,
 
+    /// Cette erreur se produit si l'analyseur syntaxique rencontre
+    /// l'identifiant système DOCTYPE qui n'est pas précédé d'un guillemet
+    /// (par exemple, `<!DOCTYPE html SYSTEM http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">`).
+    /// Dans un tel cas, l'analyseur syntaxique ignore l'identificateur de
+    /// système et, si le DOCTYPE est correctement placé en tant que
+    /// préambule du document, place le document en mode quirks.
+    MissingQuoteBeforeDOCTYPESystemIdentifier,
+
     /// Cette erreur se produit si l'analyseur syntaxique rencontre un
     /// DOCTYPE dont le mot clé "PUBLIC" et l'identifiant public ne sont
     /// pas séparés par un espace ASCII. Dans ce cas, l'analyseur se
@@ -182,6 +190,12 @@ pub enum HTMLParserError {
     /// <div id="foo"class="bar">). Dans ce cas, l'analyseur se comporte
     /// comme si un espace blanc ASCII était présent.
     MissingWhitespaceBetweenAttributes,
+
+    /// Cette erreur se produit si l'analyseur syntaxique rencontre un
+    /// DOCTYPE dont les identifiants public et système ne sont pas
+    /// séparés par un espace ASCII. Dans ce cas, l'analyseur se comporte
+    /// comme si un espace ASCII était présent.
+    MissingWhitespaceBetweenDOCTYPEPublicAndSystemIdentifiers,
 
     /// Cette erreur se produit si l'analyseur syntaxique rencontre un
     /// point de code U+0022 ("), U+0027 (') ou U+003C (<) dans un nom
@@ -295,6 +309,8 @@ impl fmt::Display for HTMLParserError {
                 | Self::MissingDOCTYPEName => "missing-doctype-name",
                 | Self::MissingQuoteBeforeDOCTYPEPublicIdentifier =>
                     "missing-quote-before-doctype-public-identifier",
+                | Self::MissingQuoteBeforeDOCTYPESystemIdentifier =>
+                    "missing-quote-before-doctype-system-identifier",
                 | Self::MissingDOCTYPEPublicIdentifier =>
                     "missing-doctype-public-identifier",
                 | Self::MissingEndTagName => "missing-end-tag-name",
@@ -304,6 +320,8 @@ impl fmt::Display for HTMLParserError {
                     "missing-whitespace-before-doctype-name",
                 | Self::MissingWhitespaceBetweenAttributes =>
                     "missing-whitespace-between-attributes",
+                | Self::MissingWhitespaceBetweenDOCTYPEPublicAndSystemIdentifiers =>
+                     "missing-whitespace-between-doctype-public-and-system-identifiers",
                 | Self::UnexpectedCharacterInAttributeName =>
                     "unexpected-character-in-attribute-name",
                 | Self::UnexpectedCharacterInUnquotedAttributeValue =>

--- a/html/parser/error.rs
+++ b/html/parser/error.rs
@@ -51,6 +51,13 @@ macro_rules! emit_html_error {
 /// tableau ci-dessous, qui doivent être utilisés par les vérificateurs de
 /// conformité dans les rapports.
 pub enum HTMLParserError {
+    /// Cette erreur se produit si l'analyseur syntaxique rencontre un
+    /// point de code U+003E (>) dans l'identifiant public DOCTYPE (par
+    /// exemple, `<!DOCTYPE html PUBLIC "foo>`). Dans un tel cas, si le
+    /// DOCTYPE est correctement placé comme préambule du document,
+    /// l'analyseur syntaxique place le document en mode quirks.
+    AbruptDOCTYPEPublicIdentifier,
+
     /// Cette erreur se produit si l'analyseur rencontre une section CDATA
     /// en dehors d'un contenu étranger (SVG ou MathML). L'analyseur
     /// syntaxique traite ces sections CDATA (y compris les chaînes de
@@ -272,6 +279,8 @@ impl fmt::Display for HTMLParserError {
             f,
             "{}",
             match self {
+                | Self::AbruptDOCTYPEPublicIdentifier =>
+                    "abrupt-doctype-public-identifier",
                 | Self::CDATAInHtmlContent => "cdata-in-html-content",
                 | Self::EofBeforeTagName => "eof-before-tag-name",
                 | Self::EofInDOCTYPE => "eof-in-doctype",

--- a/html/parser/error.rs
+++ b/html/parser/error.rs
@@ -205,6 +205,12 @@ pub enum HTMLParserError {
     /// comme si un espace ASCII était présent.
     MissingWhitespaceBetweenDOCTYPEPublicAndSystemIdentifiers,
 
+    /// Cette erreur se produit si l'analyseur syntaxique rencontre des
+    /// points de code autres que des espaces blancs ASCII ou la fermeture
+    /// U+003E (>) après l'identificateur de système DOCTYPE. L'analyseur
+    /// syntaxique ignore ces points de code.
+    UnexpectedCharacterAfterDoctypeSystemIdentifier,
+
     /// Cette erreur se produit si l'analyseur syntaxique rencontre un
     /// point de code U+0022 ("), U+0027 (') ou U+003C (<) dans un nom
     /// d'attribut. L'analyseur syntaxique inclut ces points de code dans
@@ -332,6 +338,8 @@ impl fmt::Display for HTMLParserError {
                     "missing-whitespace-between-attributes",
                 | Self::MissingWhitespaceBetweenDOCTYPEPublicAndSystemIdentifiers =>
                      "missing-whitespace-between-doctype-public-and-system-identifiers",
+                | Self::UnexpectedCharacterAfterDoctypeSystemIdentifier
+                    => "unexpected-character-after-doctype-system-identifier",
                 | Self::UnexpectedCharacterInAttributeName =>
                     "unexpected-character-in-attribute-name",
                 | Self::UnexpectedCharacterInUnquotedAttributeValue =>

--- a/html/parser/token.rs
+++ b/html/parser/token.rs
@@ -230,5 +230,13 @@ impl HTMLToken {
             *public_identifier = Some(pi);
         }
     }
+
+    pub fn set_system_identifier(&mut self, si: String) {
+        if let Self::DOCTYPE {
+            system_identifier, ..
+        } = self
+        {
+            *system_identifier = Some(si);
+        }
     }
 }

--- a/html/parser/token.rs
+++ b/html/parser/token.rs
@@ -200,6 +200,16 @@ impl HTMLToken {
         }
     }
 
+    pub fn append_character_to_system_identifier(&mut self, ch: char) {
+        if let Self::DOCTYPE {
+            system_identifier: Some(system_identifier),
+            ..
+        } = self
+        {
+            system_identifier.push(ch);
+        }
+    }
+
     pub fn define_tag_attributes(&mut self, attribute: HTMLTagAttribute) {
         assert!(matches!(
             self,

--- a/html/parser/token.rs
+++ b/html/parser/token.rs
@@ -190,6 +190,16 @@ impl HTMLToken {
         }
     }
 
+    pub fn append_character_to_public_identifier(&mut self, ch: char) {
+        if let Self::DOCTYPE {
+            public_identifier: Some(public_identifier),
+            ..
+        } = self
+        {
+            public_identifier.push(ch);
+        }
+    }
+
     pub fn define_tag_attributes(&mut self, attribute: HTMLTagAttribute) {
         assert!(matches!(
             self,
@@ -219,5 +229,6 @@ impl HTMLToken {
         {
             *public_identifier = Some(pi);
         }
+    }
     }
 }

--- a/html/parser/token.rs
+++ b/html/parser/token.rs
@@ -191,6 +191,14 @@ impl HTMLToken {
     }
 
     pub fn append_character_to_public_identifier(&mut self, ch: char) {
+        assert!(matches!(
+            self,
+            Self::DOCTYPE {
+                public_identifier: Some(_),
+                ..
+            }
+        ));
+
         if let Self::DOCTYPE {
             public_identifier: Some(public_identifier),
             ..
@@ -201,6 +209,14 @@ impl HTMLToken {
     }
 
     pub fn append_character_to_system_identifier(&mut self, ch: char) {
+        assert!(matches!(
+            self,
+            Self::DOCTYPE {
+                system_identifier: Some(_),
+                ..
+            }
+        ));
+
         if let Self::DOCTYPE {
             system_identifier: Some(system_identifier),
             ..
@@ -224,6 +240,8 @@ impl HTMLToken {
     }
 
     pub fn set_force_quirks_flag(&mut self, to: bool) {
+        assert!(matches!(self, Self::DOCTYPE { .. }));
+
         if let Self::DOCTYPE {
             force_quirks_flag, ..
         } = self
@@ -233,6 +251,14 @@ impl HTMLToken {
     }
 
     pub fn set_public_identifier(&mut self, pi: String) {
+        assert!(matches!(
+            self,
+            Self::DOCTYPE {
+                public_identifier: None,
+                ..
+            }
+        ));
+
         if let Self::DOCTYPE {
             public_identifier, ..
         } = self
@@ -242,6 +268,14 @@ impl HTMLToken {
     }
 
     pub fn set_system_identifier(&mut self, si: String) {
+        assert!(matches!(
+            self,
+            Self::DOCTYPE {
+                system_identifier: None,
+                ..
+            }
+        ));
+
         if let Self::DOCTYPE {
             system_identifier, ..
         } = self

--- a/html/parser/token.rs
+++ b/html/parser/token.rs
@@ -211,4 +211,13 @@ impl HTMLToken {
             *force_quirks_flag = to;
         }
     }
+
+    pub fn set_public_identifier(&mut self, pi: String) {
+        if let Self::DOCTYPE {
+            public_identifier, ..
+        } = self
+        {
+            *public_identifier = Some(pi);
+        }
+    }
 }


### PR DESCRIPTION
- feat(html): tokenization state: after DOCTYPE public keyword #5
- feat(html): tokenization state: Bogus DOCTYPE #5
- Merge pull request #9 from PhiSyX/feat/html_bogus_doctype 
- feat(html): tokenization state: DOCTYPE public identifier quoted #5
- feat(html): tokenization state: after DOCTYPE public identifier #5
- feat(html): tokenization state: between DOCTYPE public and system identifiers #5
- feat(html): tokenization state: DOCTYPE system identifier quoted #5
- feat(html): assertions des jetons
- feat(html): tokenization state: after DOCTYPE system identifier #5
- refactor(html): meilleur API
- feat(html): tokenization state: before DOCTYPE public identifier #5
- feat(html): tokenization state: before DOCTYPE system keyword #5
- feat(html): tokenization state: before DOCTYPE system identifier #5
