### PR TITLE
HTML Tokenization: Script data

### DIFF
--- a/html/parser/error.rs
+++ b/html/parser/error.rs
@@ -142,6 +142,23 @@ define_errors! {
     EofInDOCTYPE = "eof-in-doctype",
 
     /// Cette erreur se produit si l'analyseur syntaxique rencontre la fin
+    /// du flux d'entrée dans un texte qui ressemble à un commentaire HTML
+    /// à l'intérieur du contenu d'un élément de script (par exemple,
+    /// `<script><!-- foo`).
+    ///
+    /// Note: les structures syntaxiques qui ressemblent à des commentaires
+    /// HTML dans les éléments de script sont analysées comme du contenu
+    /// textuel. Elles peuvent faire partie d'une structure syntaxique
+    /// spécifique au langage de script ou être traitées comme un
+    /// commentaire de type HTML, si le langage de script les prend en
+    /// charge (par exemple, les règles d'analyse des commentaires de type
+    /// HTML se trouvent à l'annexe B de la spécification JavaScript). La
+    /// raison la plus courante de cette erreur est la violation des
+    /// restrictions relatives au contenu des éléments de script.
+    /// [JAVASCRIPT]
+    EofInScriptHtmlCommentLikeText = "eof-in-script-html-comment-like-text",
+
+    /// Cette erreur se produit si l'analyseur syntaxique rencontre la fin
     /// du flux d'entrée dans une balise de début ou une balise de fin
     /// (par exemple, `<div id=`). Une telle balise est ignorée.
     EofInTag = "eof-in-tag",

--- a/html/parser/tokenizer.rs
+++ b/html/parser/tokenizer.rs
@@ -1390,6 +1390,59 @@ where
         }
     }
 
+    fn handle_script_data_escaped_dash_state(
+        &mut self,
+    ) -> ResultHTMLStateIterator {
+        match self.stream.next_input_char() {
+            // U+002D HYPHEN-MINUS (-)
+            //
+            // Passer à l'état `script-data-escaped-dash-dash`.
+            // Émettre un jeton `character` U+002D HYPHEN-MINUS.
+            | Some(ch @ '-') => self
+                .switch_state_to("script-data-escaped-dash-dash")
+                .set_token(HTMLToken::Character(ch))
+                .and_emit(),
+
+            // U+003C LESS-THAN SIGN (<)
+            //
+            // Passer à l'état `script-data-escaped-less-than-sign`.
+            | Some('<') => self
+                .switch_state_to("script-data-escaped-less-than-sign")
+                .and_continue(),
+
+            // U+0000 NULL
+            //
+            // Il s'agit d'une erreur d'analyse de type
+            // `unexpected-null-character`. Passer à l'état
+            // `script-data-escaped`. Émettre un jeton `character` U+FFFD
+            // REPLACEMENT CHARACTER.
+            | Some('\0') => self
+                .switch_state_to("script-data-escaped")
+                .set_token(HTMLToken::Character(
+                    char::REPLACEMENT_CHARACTER,
+                ))
+                .and_emit(),
+
+            // EOF
+            //
+            // Il s'agit d'une erreur d'analyse de type
+            // `eof-in-script-html-comment-like-text`. Émettre un jeton
+            // `end of file`.
+            | None => self.set_token(HTMLToken::EOF).and_emit_with_error(
+                "eof-in-script-html-comment-like-text",
+            ),
+
+            // Anything else
+            //
+            // Passer à l'état `script-data-escaped`. Émettre le caractère
+            // actuel comme un jeton `character`.
+            | Some(ch) => self
+                .switch_state_to("script-data-escaped")
+                .set_token(HTMLToken::Character(ch))
+                .and_emit(),
+        }
+    }
+
     fn handle_script_data_escaped_dash_dash_state(
         &mut self,
     ) -> ResultHTMLStateIterator {
@@ -3809,7 +3862,7 @@ where
                     self.handle_script_data_escaped_state()
                 }
                 | State::ScriptDataEscapedDash => {
-                    todo!()
+                    self.handle_script_data_escaped_dash_state()
                 }
                 | State::ScriptDataEscapedDashDash => {
                     self.handle_script_data_escaped_dash_dash_state()

--- a/html/parser/tokenizer.rs
+++ b/html/parser/tokenizer.rs
@@ -205,6 +205,9 @@ define_state! {
     /// 13.2.5.20 Script data escaped state
     ScriptDataEscaped = "script-data-escaped",
 
+    /// 13.2.5.21 Script data escaped dash state
+    ScriptDataEscapedDash = "script-data-escaped-dash",
+
     /// 13.2.5.22 Script data escaped dash dash state
     ScriptDataEscapedDashDash = "script-data-escaped-dash-dash",
 
@@ -1335,6 +1338,55 @@ where
             //
             // Reprendre dans l'état `script-data`.
             | _ => self.reconsume("script-data").and_continue(),
+        }
+    }
+
+    fn handle_script_data_escaped_state(
+        &mut self,
+    ) -> ResultHTMLStateIterator {
+        match self.stream.next_input_char() {
+            // U+002D HYPHEN-MINUS (-)
+            //
+            // Passer à l'état `script-data-escaped-dash`. Émettre un jeton
+            // `character` U+002D HYPHEN-MINUS.
+            | Some(ch @ '-') => self
+                .switch_state_to("script-data-escaped-dash")
+                .set_token(HTMLToken::Character(ch))
+                .and_emit(),
+
+            // U+003C LESS-THAN SIGN (<)
+            //
+            // Passer à l'état `script-data-escaped-less-than-sign`.
+            | Some('<') => self
+                .switch_state_to("script-data-escaped-less-than-sign")
+                .and_continue(),
+
+            // U+0000 NULL
+            //
+            // Il s'agit d'une erreur d'analyse de type
+            // `unexpected-null-character`. Émettre un jeton `character`
+            // U+FFFD REPLACEMENT CHARACTER.
+            | Some('\0') => self
+                .set_token(HTMLToken::Character(
+                    char::REPLACEMENT_CHARACTER,
+                ))
+                .and_emit_with_error("unexpected-null-character"),
+
+            // EOF
+            //
+            // Il s'agit d'une erreur d'analyse de type
+            // `eof-in-script-html-comment-like-text`. Émettre un jeton
+            // `end of file`.
+            | None => self.set_token(HTMLToken::EOF).and_emit_with_error(
+                "eof-in-script-html-comment-like-text",
+            ),
+
+            // Anything else
+            //
+            // Émettre le caractère actuel comme un jeton `character`.
+            | Some(ch) => {
+                self.set_token(HTMLToken::Character(ch)).and_emit()
+            }
         }
     }
 
@@ -3754,6 +3806,9 @@ where
                     self.handle_script_data_escape_start_dash_state()
                 }
                 | State::ScriptDataEscaped => {
+                    self.handle_script_data_escaped_state()
+                }
+                | State::ScriptDataEscapedDash => {
                     todo!()
                 }
                 | State::ScriptDataEscapedDashDash => {

--- a/html/parser/tokenizer.rs
+++ b/html/parser/tokenizer.rs
@@ -591,7 +591,7 @@ where
     fn handle_rcdata_state(&mut self) -> ResultHTMLStateIterator {
         match self.stream.next_input_char() {
             // U+0026 AMPERSAND (&)
-            // Définir l'état de retour à l'état `rcdata`. Passez à l'état
+            // Définir l'état de retour à l'état `rcdata`. Passer à l'état
             // `character-reference`.
             | Some('&') => self
                 .state
@@ -634,7 +634,7 @@ where
     fn handle_rawtext_state(&mut self) -> ResultHTMLStateIterator {
         match self.stream.next_input_char() {
             // U+003C LESS-THAN SIGN (<)
-            // Passez à l'état `rawtext-less-than-sign`.
+            // Passer à l'état `rawtext-less-than-sign`.
             | Some('<') => self
                 .state
                 .switch_to("rawtext-less-than-sign")
@@ -820,8 +820,8 @@ where
             // U+0020 SPACE
             //
             // Si le jeton `end tag` actuel est un jeton `end tag`
-            // approprié, passez à l'état `before-attribute-name`. Sinon,
-            // traitez-le comme indiqué dans l'entrée "Anything
+            // approprié, passer à l'état `before-attribute-name`. Sinon,
+            // le traiter comme indiqué dans l'entrée "Anything
             // else" ci-dessous.
             | Some(ch) if ch.is_html_whitespace() => self
                 .state
@@ -831,8 +831,8 @@ where
             // U+002F SOLIDUS (/)
             //
             // Si le jeton `end tag` actuel est un jeton `end tag`
-            // approprié, passez l'état de balise de
-            // `self-closing-start-tag`. Sinon, traitez-le comme dans
+            // approprié, passer l'état de balise de
+            // `self-closing-start-tag`. Sinon, le traiter comme dans
             // l'entrée "Anything else" ci-dessous.
             | Some('/') => self
                 .state
@@ -948,7 +948,7 @@ where
             //
             // Si le jeton `end tag` actuel est un jeton `end tag`
             // approprié, alors passer à l'état `before-attribute-name`.
-            // Sinon, traitez-le comme indiqué dans l'entrée
+            // Sinon, le traiter comme indiqué dans l'entrée
             // "Anything else" ci-dessous.
             | Some(ch)
                 if ch.is_html_whitespace()
@@ -963,7 +963,7 @@ where
             //
             // Si le jeton `end tag` actuel est un jeton `end tag`
             // approprié, alors passer à l'état `self-closing-start-tag`.
-            // Sinon, traitez-le comme indiqué dans l'entrée
+            // Sinon, le traiter comme indiqué dans l'entrée
             // "Anything else" ci-dessous.
             | Some('/') if self.is_appropriate_end_tag() => self
                 .state
@@ -974,7 +974,7 @@ where
             //
             // Si le jeton `end tag` actuel est un jeton `end tag`
             // approprié, alors passer à l'état `data` et émettre le jeton
-            // courant. Sinon, traitez-le comme indiqué dans l'entrée
+            // courant. Sinon, le traiter comme indiqué dans l'entrée
             // "Anything else" ci-dessous.
             | Some('>') if self.is_appropriate_end_tag() => {
                 self.state.switch_to("data").and_emit()
@@ -1083,7 +1083,7 @@ where
             //
             // Si le jeton `end-tag` actuel est un jeton `end-tag`
             // approprié, alors passer à l'état `before-attribute-name`.
-            // Sinon, traitez-le comme indiqué dans l'entrée "Anything
+            // Sinon, le traiter comme indiqué dans l'entrée "Anything
             // else" ci-dessous.
             | Some(ch)
                 if ch.is_html_whitespace()
@@ -1098,7 +1098,7 @@ where
             //
             // Si le jeton `end-tag` actuel est un jeton `end-tag`
             // approprié, passer à l'état à `self-closing-start-tag`.
-            // Sinon, traitez-le comme indiqué dans l'entrée
+            // Sinon, le traiter comme indiqué dans l'entrée
             // "Anything else" ci-dessous.
             | Some('/') if self.is_appropriate_end_tag() => self
                 .state
@@ -1108,8 +1108,8 @@ where
             // U+003E GREATER-THAN SIGN (>)
             //
             // Si le jeton `end-tag` actuel est un jeton `end-tag`
-            // approprié, passer à l'état `data` et émettez
-            // le jeton `end-tag` actuel. Sinon, traitez-le comme
+            // approprié, passer à l'état `data` et émettre
+            // le jeton `end-tag` actuel. Sinon, le traiter comme
             // indiqué dans l'entrée "Anything else" ci-dessous.
             | Some('>') if self.is_appropriate_end_tag() => {
                 self.state.switch_to("data").and_emit()
@@ -1225,7 +1225,7 @@ where
             //
             // Si le jeton `end-tag` actuel est un jeton `end-tag`
             // approprié, il faut passer à l'état `before-attribute-name`.
-            // Sinon, traitez-le comme indiqué dans l'entrée `Anything
+            // Sinon, le traiter comme indiqué dans l'entrée `Anything
             // else` ci-dessous.
             | Some(ch)
                 if ch.is_html_whitespace()
@@ -1240,7 +1240,7 @@ where
             //
             // Si le jeton `end-tag` actuel est un jeton `end-tag`
             // approprié, il faut passer à l'état `self-closing-start-tag`.
-            // Sinon, traitez-le comme indiqué dans l'entrée `Anything
+            // Sinon, le traiter comme indiqué dans l'entrée `Anything
             // else` ci-dessous.
             | Some('/') if self.is_appropriate_end_tag() => self
                 .state
@@ -1251,7 +1251,7 @@ where
             //
             // Si le jeton `end-tag` actuel est un jeton `end-tag`
             // approprié, il faut passer à l'état `data`.
-            // Sinon, traitez-le comme indiqué dans l'entrée `Anything
+            // Sinon, le traiter comme indiqué dans l'entrée `Anything
             // else` ci-dessous.
             | Some('>') if self.is_appropriate_end_tag() => {
                 self.state.switch_to("data").and_continue()
@@ -1809,7 +1809,7 @@ where
 
             // U+003E GREATER-THAN SIGN (>)
             //
-            // Passer à l'état `data`. Émettez le jeton `tag` actuel.
+            // Passer à l'état `data`. Émettre le jeton `tag` actuel.
             | Some('>') => self.state.switch_to("data").and_emit(),
 
             // EOF
@@ -2026,7 +2026,7 @@ where
         match self.stream.next_input_char() {
             // U+002D HYPHEN-MINUS (-)
             //
-            // Passez à l'état `comment-less-than-sign-bang-dash`.
+            // Passer à l'état `comment-less-than-sign-bang-dash`.
             | Some('-') => self
                 .state
                 .switch_to("comment-less-than-sign-bang-dash")
@@ -2045,7 +2045,7 @@ where
         match self.stream.next_input_char() {
             // U+002D HYPHEN-MINUS (-)
             //
-            // Passez à l'état `comment-less-than-sign-bang-dash-dash`.
+            // Passer à l'état `comment-less-than-sign-bang-dash-dash`.
             | Some('-') => self
                 .state
                 .switch_to("comment-less-than-sign-bang-dash-dash")
@@ -2073,7 +2073,7 @@ where
             // Anything else
             //
             // Il s'agit d'une erreur d'analyse de type `nested-comment`.
-            // Reprenez à l'état `comment-end`.
+            // Reprendre dans l'état `comment-end`.
             | Some(_) => self
                 .reconsume("comment-end")
                 .and_continue_with_error("nested-comment"),
@@ -2086,7 +2086,7 @@ where
         match self.stream.next_input_char() {
             // U+002D HYPHEN-MINUS (-)
             //
-            // Passez à l'état final du commentaire.
+            // Passer à l'état final du commentaire.
             | Some('-') => {
                 self.state.switch_to("comment-end").and_continue()
             }
@@ -2220,7 +2220,7 @@ where
 
             // U+0021 EXCLAMATION MARK (!)
             //
-            // Passez à l'état `comment-end-bang`.
+            // Passer à l'état `comment-end-bang`.
             | Some('!') => {
                 self.state.switch_to("comment-end-bang").and_continue()
             }
@@ -2280,7 +2280,7 @@ where
             // U+003E GREATER-THAN SIGN (>)
             //
             // Il s'agit d'une erreur d'analyse de type
-            // `incorrectly-closed-comment`. Passez à l'état `data`.
+            // `incorrectly-closed-comment`. Passer à l'état `data`.
             // Émettre le jeton `comment` actuel.
             | Some('>') => self
                 .switch_state_to("data")
@@ -2371,7 +2371,7 @@ where
             //
             // Créer un nouveau jeton `doctype`. Définir le nom du jeton
             // comme la version en minuscules du caractère actuel
-            // (ajoutez 0x0020 au point de code du caractère). Passer à
+            // (ajouter 0x0020 au point de code du caractère). Passer à
             // l'état `doctype-name`.
             | Some(ch) if ch.is_ascii_uppercase() => self
                 .set_token(
@@ -2536,12 +2536,12 @@ where
             //
             // Si les six caractères à partir du caractère actuel sont une
             // correspondance ASCII insensible à la casse pour le
-            // mot "PUBLIC", consommez ces caractères et passez à l'état
+            // mot "PUBLIC", consommer ces caractères et passer à l'état
             // `after-doctype-public-keyword`.
             //
             // Sinon, si les six caractères à partir du caractère d'entrée
             // actuel sont une correspondance ASCII insensible à la casse
-            // pour le mot "SYSTEM", consommez ces caractères et passez à
+            // pour le mot "SYSTEM", consommer ces caractères et passer à
             // l'état `after-doctype-system-keyword`.
             //
             // Sinon, il s'agit d'une erreur d'analyse de type
@@ -3151,7 +3151,7 @@ where
             // U+0022 QUOTATION MARK (")
             // U+0027 APOSTROPHE (')
             //
-            // Passez à l'état `after-doctype-system-identifier`.
+            // Passer à l'état `after-doctype-system-identifier`.
             | Some(ch) if ch == quote => self
                 .state
                 .switch_to("after-doctype-system-identifier")
@@ -3260,7 +3260,7 @@ where
         match self.stream.next_input_char() {
             // U+003E GREATER-THAN SIGN (>)
             //
-            // Passer à l'état `data`. Émettez le jeton `doctype`.
+            // Passer à l'état `data`. Émettre le jeton `doctype`.
             | Some('>') => self.state.switch_to("data").and_emit(),
 
             // U+0000 NULL
@@ -3480,7 +3480,7 @@ where
             // Anything else
             //
             // Il s'agit d'une erreur d'analyse de type
-            // `absence-of-digits-in-numeric-character-reference`. Videz
+            // `absence-of-digits-in-numeric-character-reference`. Vider
             // les points de code consommés comme référence de caractère.
             // Reprendre dans l'état `return-state`.
             | _ => self
@@ -3506,7 +3506,7 @@ where
             // Anything else
             //
             // Il s'agit d'une erreur d'analyse de type
-            // `absence-of-digits-in-numeric-character-reference`. Videz
+            // `absence-of-digits-in-numeric-character-reference`. Vider
             // les points de code consommés comme référence de caractère.
             // Reprendre dans l'état `return-state`.
             | _ => self
@@ -3638,8 +3638,8 @@ where
 
             // Si le nombre est supérieur à 0x10FFFF, il s'agit d'une
             // erreur d'analyse de référence de caractère hors
-            // de la plage unicode. Définissez le code de
-            // référence du caractère à 0xFFFD.
+            // de la plage unicode. Définir le code de référence du
+            // caractère à 0xFFFD.
             | crc if crc > 0x10FFFF => {
                 err = "character-reference-outside-unicode-range".into();
                 self.character_reference_code = 0xFFFD;
@@ -3662,8 +3662,8 @@ where
             // Si le nombre est 0x0D, ou un contrôle qui n'est pas un
             // espace ASCII, il s'agit d'une erreur d'analyse de référence
             // de caractère de contrôle. Si le nombre est l'un des nombres
-            // de la première colonne du tableau suivant, trouvez la ligne
-            // avec ce nombre dans la première colonne, et définissez le
+            // de la première colonne du tableau suivant, trouver la ligne
+            // avec ce nombre dans la première colonne, et définir le
             // code de référence de caractère au nombre de la deuxième
             // colonne de cette ligne.
             | crc if crc == 0x0D

--- a/html/parser/tokenizer.rs
+++ b/html/parser/tokenizer.rs
@@ -202,6 +202,9 @@ define_state! {
     /// 13.2.5.19 Script data escape start dash state
     ScriptDataEscapeStartDash = "script-data-escape-start-dash",
 
+    /// 13.2.5.22 Script data escaped dash dash state
+    ScriptDataEscapedDashDash = "script-data-escaped-dash-dash",
+
     /// 13.2.5.32 Before attribute name state
     BeforeAttributeName = "before-attribute-name",
 
@@ -1299,6 +1302,26 @@ where
             // jeton `character` U+002D HYPHEN-MINUS.
             | Some(ch @ '-') => self
                 .switch_state_to("script-data-escape-start-dash")
+                .set_token(HTMLToken::Character(ch))
+                .and_emit(),
+
+            // Anything else
+            //
+            // Reprendre dans l'état `script-data`.
+            | _ => self.reconsume("script-data").and_continue(),
+        }
+    }
+
+    fn handle_script_data_escape_start_dash_state(
+        &mut self,
+    ) -> ResultHTMLStateIterator {
+        match self.stream.next_input_char() {
+            // U+002D HYPHEN-MINUS (-)
+            //
+            // Passer à l'état `script-data-escaped-dash-dash`.
+            // Émettre un jeton `character` U+002D HYPHEN-MINUS.
+            | Some(ch @ '-') => self
+                .switch_state_to("script-data-escaped-dash-dash")
                 .set_token(HTMLToken::Character(ch))
                 .and_emit(),
 
@@ -3662,6 +3685,9 @@ where
                     self.handle_script_data_escape_start_state()
                 }
                 | State::ScriptDataEscapeStartDash => {
+                    self.handle_script_data_escape_start_dash_state()
+                }
+                | State::ScriptDataEscapedDashDash => {
                     todo!()
                 }
                 | State::BeforeAttributeName => {

--- a/html/parser/tokenizer.rs
+++ b/html/parser/tokenizer.rs
@@ -1202,6 +1202,90 @@ where
         }
     }
 
+    fn handle_script_data_end_tag_name_state(
+        &mut self,
+    ) -> ResultHTMLStateIterator {
+        match self.stream.next_input_char() {
+            // U+0009 CHARACTER TABULATION (tab)
+            // U+000A LINE FEED (LF)
+            // U+000C FORM FEED (FF)
+            // U+0020 SPACE
+            //
+            // Si le jeton `end-tag` actuel est un jeton `end-tag`
+            // approprié, il faut passer à l'état `before-attribute-name`.
+            // Sinon, traitez-le comme indiqué dans l'entrée `Anything
+            // else` ci-dessous.
+            | Some(ch)
+                if ch.is_html_whitespace()
+                    && self.is_appropriate_end_tag() =>
+            {
+                self.state
+                    .switch_to("before-attribute-name")
+                    .and_continue()
+            }
+
+            // U+002F SOLIDUS (/)
+            //
+            // Si le jeton `end-tag` actuel est un jeton `end-tag`
+            // approprié, il faut passer à l'état `self-closing-start-tag`.
+            // Sinon, traitez-le comme indiqué dans l'entrée `Anything
+            // else` ci-dessous.
+            | Some('/') if self.is_appropriate_end_tag() => self
+                .state
+                .switch_to("self-closing-start-tag")
+                .and_continue(),
+
+            // U+003E GREATER-THAN SIGN (>)
+            //
+            // Si le jeton `end-tag` actuel est un jeton `end-tag`
+            // approprié, il faut passer à l'état `data`.
+            // Sinon, traitez-le comme indiqué dans l'entrée `Anything
+            // else` ci-dessous.
+            | Some('>') if self.is_appropriate_end_tag() => {
+                self.state.switch_to("data").and_continue()
+            }
+
+            // ASCII upper alpha
+            //
+            // Ajouter la version en minuscules du caractère d'entrée
+            // actuel (ajouter 0x0020 au point de code du caractère) au nom
+            // de la balise du jeton `*-tag` actuel. Ajouter le caractère
+            // actuel au tampon temporaire.
+            | Some(ch) if ch.is_ascii_uppercase() => self
+                .change_current_token(|tag_tok| {
+                    tag_tok.append_character(ch.to_ascii_lowercase())
+                })
+                .append_character_to_temporary_buffer(ch)
+                .and_continue(),
+
+            // ASCII lower alpha
+            //
+            // Ajouter le caractère actuel au nom de la balise du jeton
+            // `*-tag` actuel. Ajouter le caractère actuel au tampon
+            // temporaire.
+            | Some(ch) if ch.is_ascii_lowercase() => self
+                .change_current_token(|tag_tok| {
+                    tag_tok.append_character(ch)
+                })
+                .append_character_to_temporary_buffer(ch)
+                .and_continue(),
+
+            // Anything else
+            //
+            // Émettre un jeton `character` U+003C LESS-THAN SIGN, un
+            // jeton `character` U+002F SOLIDUS et un jeton `character`
+            // pour chacun des caractères du tampon temporaire (dans
+            // l'ordre où ils ont été ajoutés au tampon). Reprendre dans
+            // l'état `script-data`.
+            | _ => self
+                .emit_token(HTMLToken::Character('<'))
+                .emit_token(HTMLToken::Character('/'))
+                .emit_each_characters_of_temporary_buffer()
+                .reconsume("script-data")
+                .and_continue(),
+        }
+    }
+
     fn handle_before_attribute_name_state(
         &mut self,
     ) -> ResultHTMLStateIterator {
@@ -3549,7 +3633,7 @@ where
                     self.handle_script_data_end_tag_open_state()
                 }
                 | State::ScriptDataEndTagName => {
-                    todo!()
+                    self.handle_script_data_end_tag_name_state()
                 }
                 | State::ScriptDataEscapeStart => {
                     todo!()


### PR DESCRIPTION
- feat(html): tokenization state: script data #23
- feat(html): tokenization state: script data less than sign #23
- feat(html): tokenization state: script data end tag open #23
- feat(html): tokenization state: script data end tag name #23
- feat(html): tokenization state: script data escape start #23
- feat(html): tokenization state: script data escape start dash #23
- feat(html): tokenization state: script data escaped dash dash #23
- docs(html): typo
- feat(html): tokenization state: script data escaped #23
- feat(html): tokenization state: script data escaped dash #23
- feat(html): tokenization state: script data escaped less than sign #23
- feat(html): tokenization state: script data escaped end tag open state #23
- feat(html): tokenization state: script data escaped end tag name state #23
- feat(html): tokenization state: script double escape start #23
- feat(html): tokenization state: script double escaped #23
- feat(html): tokenization state: script data double escaped dash #23
- feat(html): tokenization state: script data double escaped dash dash #23
- feat(html): tokenization state: script data double escaped less than sign #23
- feat(html): tokenization state: script data double escape end #23
