### PR TITLE
HTML Tokenization

### DIFF
--- a/html/parser/error.rs
+++ b/html/parser/error.rs
@@ -142,6 +142,23 @@ define_errors! {
     EofInDOCTYPE = "eof-in-doctype",
 
     /// Cette erreur se produit si l'analyseur syntaxique rencontre la fin
+    /// du flux d'entrée dans un texte qui ressemble à un commentaire HTML
+    /// à l'intérieur du contenu d'un élément de script (par exemple,
+    /// `<script><!-- foo`).
+    ///
+    /// Note: les structures syntaxiques qui ressemblent à des commentaires
+    /// HTML dans les éléments de script sont analysées comme du contenu
+    /// textuel. Elles peuvent faire partie d'une structure syntaxique
+    /// spécifique au langage de script ou être traitées comme un
+    /// commentaire de type HTML, si le langage de script les prend en
+    /// charge (par exemple, les règles d'analyse des commentaires de type
+    /// HTML se trouvent à l'annexe B de la spécification JavaScript). La
+    /// raison la plus courante de cette erreur est la violation des
+    /// restrictions relatives au contenu des éléments de script.
+    /// [JAVASCRIPT]
+    EofInScriptHtmlCommentLikeText = "eof-in-script-html-comment-like-text",
+
+    /// Cette erreur se produit si l'analyseur syntaxique rencontre la fin
     /// du flux d'entrée dans une balise de début ou une balise de fin
     /// (par exemple, `<div id=`). Une telle balise est ignorée.
     EofInTag = "eof-in-tag",

--- a/html/parser/tokenizer.rs
+++ b/html/parser/tokenizer.rs
@@ -352,6 +352,15 @@ define_state! {
     /// 13.2.5.68 Bogus DOCTYPE state
     BogusDOCTYPE = "bogus-doctype",
 
+    /// 13.2.5.69 CDATA section state
+    CDATASection = "cdata-section",
+
+    /// 13.2.5.70 CDATA section bracket state
+    CDATASectionBracket = "cdata-section-bracket",
+
+    /// 13.2.5.71 CDATA section end state
+    CDATASectionEnd = "cdata-section-end",
+
     /// 13.2.5.72 Character reference state
     CharacterReference = "character-reference",
 
@@ -3909,6 +3918,82 @@ where
         }
     }
 
+    fn handle_cdata_section_state(&mut self) -> ResultHTMLStateIterator {
+        match self.stream.next_input_char() {
+            // U+005D RIGHT SQUARE BRACKET (])
+            //
+            // Passer à l'état `cdata-section-bracket`.
+            | Some(']') => self
+                .switch_state_to("cdata-section-bracket")
+                .and_continue(),
+
+            // EOF
+            //
+            // Il s'agit d'une erreur d'analyse de type `eof-in-cdata`.
+            // Émettre un jeton `end-of-file`.
+            | None => self
+                .set_token(HTMLToken::EOF)
+                .and_emit_with_error("eof-in-cdata"),
+
+            // Anything else
+            //
+            // Émettre le caractère actuel comme un jeton de `character`.
+            | Some(ch) => {
+                self.set_token(HTMLToken::Character(ch)).and_emit()
+            }
+        }
+    }
+
+    fn handle_cdata_section_bracket_state(
+        &mut self,
+    ) -> ResultHTMLStateIterator {
+        match self.stream.next_input_char() {
+            // U+005D RIGHT SQUARE BRACKET (])
+            //
+            // Passez à l'état `cdata-section-end`.
+            | Some(']') => {
+                self.switch_state_to("cdata-section-end").and_continue()
+            }
+
+            // Anything else
+            //
+            // Émettre un jeton `character `U+005D RIGHT SQUARE BRACKET.
+            // Reprendre dans l'état de `cdata-section`.
+            | _ => self
+                .emit_token(HTMLToken::Character(']'))
+                .reconsume("cdata-section")
+                .and_continue(),
+        }
+    }
+
+    fn handle_cdata_section_end_state(
+        &mut self,
+    ) -> ResultHTMLStateIterator {
+        match self.stream.next_input_char() {
+            // U+005D RIGHT SQUARE BRACKET (])
+            //
+            // Émettre un jeton `character` U+005D RIGHT SQUARE BRACKET.
+            | Some(ch @ ']') => {
+                self.set_token(HTMLToken::Character(ch)).and_emit()
+            }
+
+            // U+003E GREATER-THAN SIGN character
+            //
+            // Passer à l'état `data`.
+            | Some('>') => self.switch_state_to("data").and_continue(),
+
+            // Anything else
+            //
+            // Émettre deux jetons `character` U+005D RIGHT SQUARE BRACKET.
+            // Reprendre dans l'état `cdata-section`.
+            | _ => self
+                .emit_token(HTMLToken::Character(']'))
+                .emit_token(HTMLToken::Character(']'))
+                .reconsume("cdata-section")
+                .and_continue(),
+        }
+    }
+
     fn handle_character_reference_state(
         &mut self,
     ) -> ResultHTMLStateIterator {
@@ -4509,6 +4594,13 @@ where
                     self.handle_after_doctype_system_identifier_state()
                 }
                 | State::BogusDOCTYPE => self.handle_bogus_doctype_state(),
+                | State::CDATASection => self.handle_cdata_section_state(),
+                | State::CDATASectionBracket => {
+                    self.handle_cdata_section_bracket_state()
+                }
+                | State::CDATASectionEnd => {
+                    self.handle_cdata_section_end_state()
+                }
                 | State::CharacterReference => {
                     self.handle_character_reference_state()
                 }


### PR DESCRIPTION
- feat(html): tokenization state: script data #23
- feat(html): tokenization state: script data less than sign #23
- feat(html): tokenization state: script data end tag open #23
- feat(html): tokenization state: script data end tag name #23
- feat(html): tokenization state: script data escape start #23
- feat(html): tokenization state: script data escape start dash #23
- feat(html): tokenization state: script data escaped dash dash #23
- docs(html): typo
- feat(html): tokenization state: script data escaped #23
- feat(html): tokenization state: script data escaped dash #23
- feat(html): tokenization state: script data escaped less than sign #23
- feat(html): tokenization state: script data escaped end tag open state #23
- feat(html): tokenization state: script data escaped end tag name state #23
- feat(html): tokenization state: script double escape start #23
- feat(html): tokenization state: script double escaped #23
- feat(html): tokenization state: script data double escaped dash #23
- feat(html): tokenization state: script data double escaped dash dash #23
- feat(html): tokenization state: script data double escaped less than sign #23
- feat(html): tokenization state: script data double escape end #23
- feat(html): tokenization state: plaintext #24
- feat(html): tokenization state: cdata section #25
- feat(html): tokenization state: cdata section bracket #25
- feat(html): tokenization state: cdata section end #25
