### PR TITLE
HTML Tree Construction: le mode d'insertion "after body"

### DIFF
--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -3291,6 +3291,20 @@ where
 
     fn handle_after_body_insertion_mode(&mut self, token: HTMLToken) {
         match token {
+            // U+0009 CHARACTER TABULATION
+            // U+000A LINE FEED (LF)
+            // U+000C FORM FEED (FF)
+            // U+000D CARRIAGE RETURN (CR)
+            // U+0020 SPACE
+            //
+            // Traiter le jeton en utilisant les règles du mode d'insertion
+            // "in body".
+            | HTMLToken::Character(ch) if ch.is_ascii_whitespace() => {
+                self.process_using_the_rules_for(
+                    InsertionMode::InBody,
+                    token,
+                );
+            }
             // Anything else
             //
             // Erreur d'analyse. Passer le mode d'insertion à "in body" et

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -3364,6 +3364,14 @@ where
                 self.insertion_mode
                     .switch_to(InsertionMode::AfterAfterBody);
             }
+
+            // An end-of-file token
+            //
+            // Arrêter l'analyse.
+            | HTMLToken::EOF => {
+                self.stop_parsing = true;
+            }
+
             // Anything else
             //
             // Erreur d'analyse. Passer le mode d'insertion à "in body" et

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -218,7 +218,9 @@ where
             | InsertionMode::InSelect => todo!(),
             | InsertionMode::InSelectInTable => todo!(),
             | InsertionMode::InTemplate => todo!(),
-            | InsertionMode::AfterBody => todo!(),
+            | InsertionMode::AfterBody => {
+                self.handle_after_body_insertion_mode(token)
+            }
             | InsertionMode::InFrameset => todo!(),
             | InsertionMode::AfterFrameset => todo!(),
             | InsertionMode::AfterAfterBody => todo!(),
@@ -3283,6 +3285,23 @@ where
             // Any other end tag
             | HTMLToken::Tag(HTMLTagToken { is_end: true, .. }) => {
                 handle_any_other_end_tag(self, &token);
+            }
+        }
+    }
+
+    fn handle_after_body_insertion_mode(&mut self, token: HTMLToken) {
+        match token {
+            // Anything else
+            //
+            // Erreur d'analyse. Passer le mode d'insertion à "in body" et
+            // retraiter le jeton.
+            | _ => {
+                self.parse_error(token.clone());
+                self.insertion_mode.switch_to(InsertionMode::InBody);
+                self.process_using_the_rules_for(
+                    self.insertion_mode,
+                    token,
+                );
             }
         }
     }

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -3320,6 +3320,14 @@ where
                     insertion_location.append_child(comment.to_owned());
                 }
             }
+
+            // A DOCTYPE token
+            //
+            // Erreur d'analyse. Ignorer le jeton.
+            | HTMLToken::DOCTYPE(_) => {
+                self.parse_error(token);
+                /* Ignore */
+            }
             // Anything else
             //
             // Erreur d'analyse. Passer le mode d'insertion à "in body" et

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -3305,6 +3305,21 @@ where
                     token,
                 );
             }
+
+            // A comment token
+            //
+            // Insérer un commentaire comme dernier enfant du premier
+            // élément de la pile d'éléments ouverts (l'élément html).
+            | HTMLToken::Comment(comment) => {
+                let maybe_insertion_location =
+                    self.stack_of_open_elements.first();
+                if let Some(insertion_location) = maybe_insertion_location
+                {
+                    let comment =
+                        CommentNode::new(&self.document, comment);
+                    insertion_location.append_child(comment.to_owned());
+                }
+            }
             // Anything else
             //
             // Erreur d'analyse. Passer le mode d'insertion à "in body" et


### PR DESCRIPTION
- feat(html): jeton anything else #41
- feat(html): jeton character #41
- feat(html): jeton commentaire #41
- feat(html): jeton DOCTYPE #41
- feat(html): jeton balise "html" #41
- feat(html): jeton EOF #41
