### PR TITLE
HTML Tree Construction: le mode d'insertion "after after body"

### DIFF
--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -223,7 +223,9 @@ where
             }
             | InsertionMode::InFrameset => todo!(),
             | InsertionMode::AfterFrameset => todo!(),
-            | InsertionMode::AfterAfterBody => todo!(),
+            | InsertionMode::AfterAfterBody => {
+                self.handle_after_after_body_insertion_mode(token);
+            }
             | InsertionMode::AfterAfterFrameset => todo!(),
         }
     }
@@ -3372,6 +3374,26 @@ where
                 self.stop_parsing = true;
             }
 
+            // Anything else
+            //
+            // Erreur d'analyse. Passer le mode d'insertion à "in body" et
+            // retraiter le jeton.
+            | _ => {
+                self.parse_error(token.clone());
+                self.insertion_mode.switch_to(InsertionMode::InBody);
+                self.process_using_the_rules_for(
+                    self.insertion_mode,
+                    token,
+                );
+            }
+        }
+    }
+
+    fn handle_after_after_body_insertion_mode(
+        &mut self,
+        token: HTMLToken,
+    ) {
+        match token {
             // Anything else
             //
             // Erreur d'analyse. Passer le mode d'insertion à "in body" et

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -3488,6 +3488,9 @@ mod tests {
     fn test_parse_document() {
         let mut parser = load_fixture!("crashtests/test.html");
         parser.run();
+        panic!(
+            "[pour le test]: je veux paniquer même si tout fonctionne !"
+        );
     }
 
     #[test]

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -3394,6 +3394,15 @@ where
         token: HTMLToken,
     ) {
         match token {
+            // A comment token
+            //
+            // Insérer un commentaire comme dernier enfant de l'objet
+            // Document.
+            | HTMLToken::Comment(comment) => {
+                let comment = CommentNode::new(&self.document, comment);
+                self.document.append_child(comment.to_owned());
+            }
+
             // Anything else
             //
             // Erreur d'analyse. Passer le mode d'insertion à "in body" et

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -3403,6 +3403,39 @@ where
                 self.document.append_child(comment.to_owned());
             }
 
+            // A DOCTYPE token,
+            // U+0009 CHARACTER TABULATION
+            // U+000A LINE FEED (LF)
+            // U+000C FORM FEED (FF)
+            // U+000D CARRIAGE RETURN (CR)
+            // U+0020 SPACE,
+            // A start tag whose tag name is "html"
+            //
+            // Traiter le jeton en utilisant les règles du mode d'insertion
+            // "in body".
+            | HTMLToken::DOCTYPE(_) => {
+                self.process_using_the_rules_for(
+                    InsertionMode::InBody,
+                    token,
+                );
+            }
+            | HTMLToken::Character(ch) if ch.is_ascii_whitespace() => {
+                self.process_using_the_rules_for(
+                    InsertionMode::InBody,
+                    token,
+                );
+            }
+            | HTMLToken::Tag(HTMLTagToken {
+                ref name,
+                is_end: false,
+                ..
+            }) if tag_names::html == name => {
+                self.process_using_the_rules_for(
+                    InsertionMode::InBody,
+                    token,
+                );
+            }
+
             // Anything else
             //
             // Erreur d'analyse. Passer le mode d'insertion à "in body" et

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -3436,6 +3436,13 @@ where
                 );
             }
 
+            // An end-of-file token
+            //
+            // Arrêter l'analyse.
+            | HTMLToken::EOF => {
+                self.stop_parsing = true;
+            }
+
             // Anything else
             //
             // Erreur d'analyse. Passer le mode d'insertion à "in body" et


### PR DESCRIPTION
- feat(html): jeton anything else #43
- feat(html): jeton commentaire #43
- feat(html): jeton doctype, caractère, balise #43
- feat(html): jeton EOF #43
- chore(html): panic explicite pour le test
