### PR TITLE
HTML Tree Construction: le mode d'insertion "in body"

### DIFF
--- a/dom/Cargo.toml
+++ b/dom/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-dom"
-version = "0.1.0"
+version = "0.1.1"
 license-file = "../LICENSE"
 edition = "2021"
 

--- a/dom/node/attr.rs
+++ b/dom/node/attr.rs
@@ -2,15 +2,25 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::cell::RefCell;
+use infra::primitive::string::DOMString;
 
 // --------- //
 // Structure //
 // --------- //
 
 #[derive(Debug)]
-#[derive(PartialEq)]
 pub struct Attr {
-    name: RefCell<String>,
-    value: RefCell<String>,
+    name: DOMString,
+    value: DOMString,
+}
+
+// -------------- //
+// Implémentation // -> Interface
+// -------------- //
+
+impl PartialEq for Attr {
+    fn eq(&self, other: &Self) -> bool {
+        *self.name.read() == *other.name.read()
+            && *self.value.read() == *other.value.read()
+    }
 }

--- a/dom/node/character_data.rs
+++ b/dom/node/character_data.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::cell::RefCell;
+use infra::primitive::string::DOMString;
 
 use super::{Comment, Text};
 
@@ -11,10 +11,9 @@ use super::{Comment, Text};
 // --------- //
 
 #[derive(Debug)]
-#[derive(PartialEq)]
 pub struct CharacterData {
     inner: CharacterDataInner,
-    data: RefCell<String>,
+    data: DOMString,
 }
 
 #[derive(Debug)]
@@ -37,6 +36,18 @@ impl CharacterData {
     }
 
     pub fn set_data(&self, data: &str) {
-        self.data.replace(data.to_owned());
+        let dom_string = DOMString::new(data);
+        self.data.write(dom_string);
+    }
+}
+
+// -------------- //
+// Implémentation // -> Interface
+// -------------- //
+
+impl PartialEq for CharacterData {
+    fn eq(&self, other: &Self) -> bool {
+        self.inner == other.inner
+            && *self.data.read() == *other.data.read()
     }
 }

--- a/dom/node/document.rs
+++ b/dom/node/document.rs
@@ -121,6 +121,10 @@ impl Document {
     pub fn get_doctype(&self) -> RwLockReadGuard<Option<DocumentType>> {
         self.doctype.read().unwrap()
     }
+
+    pub fn isin_quirks_mode(&self) -> bool {
+        matches!(*self.quirks_mode.read().unwrap(), QuirksMode::Yes)
+    }
 }
 
 // &mut Self

--- a/dom/node/document.rs
+++ b/dom/node/document.rs
@@ -5,7 +5,7 @@
 use core::ops;
 use std::{
     borrow::{Borrow, BorrowMut},
-    cell::RefCell,
+    cell::{Ref, RefCell},
 };
 
 use html_elements::tag_names;
@@ -34,7 +34,7 @@ pub struct DocumentNode {
 #[derive(PartialEq)]
 pub struct Document {
     doctype: RefCell<Option<DocumentType>>,
-    quirks_mode: RefCell<QuirksMode>,
+    pub quirks_mode: RefCell<QuirksMode>,
 }
 
 // ----------- //
@@ -115,6 +115,12 @@ impl Document {
                 )
             })
             .map_err(|_| DOMException::InvalidNodeTypeError)
+    }
+}
+
+impl Document {
+    pub fn get_doctype(&self) -> Ref<'_, Option<DocumentType>> {
+        self.doctype.borrow()
     }
 }
 

--- a/dom/node/document_fragment.rs
+++ b/dom/node/document_fragment.rs
@@ -31,16 +31,6 @@ pub struct DocumentFragment {}
 // -------------- //
 
 impl DocumentFragmentNode {
-    fn new(fragment: DocumentFragment) -> Self {
-        let tree = TreeNode::new(
-            Node::builder()
-                .set_data(Self::document_fragment(fragment))
-                .set_type(NodeType::DOCUMENT_FRAGMENT_NODE)
-                .build(),
-        );
-        Self { tree }
-    }
-
     pub fn document_fragment(fragment: DocumentFragment) -> NodeData {
         NodeData::DocumentFragment {
             fragment: fragment.into(),

--- a/dom/node/document_type.rs
+++ b/dom/node/document_type.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use infra::primitive::string::DOMString;
+
 // --------- //
 // Structure //
 // --------- //
@@ -11,9 +13,9 @@
 #[derive(Debug)]
 #[derive(PartialEq)]
 pub struct DocumentType {
-    pub name: String,
-    pub public_id: String,
-    pub system_id: String,
+    pub name: DOMString,
+    pub public_id: DOMString,
+    pub system_id: DOMString,
 }
 
 // -------------- //
@@ -28,12 +30,12 @@ impl DocumentType {
     pub fn new(name: Option<&String>) -> Self {
         Self {
             name: if let Some(x) = name {
-                x.to_owned()
+                DOMString::new(x)
             } else {
-                String::new()
+                Default::default()
             },
-            public_id: String::new(),
-            system_id: String::new(),
+            public_id: Default::default(),
+            system_id: Default::default(),
         }
     }
 }
@@ -41,9 +43,9 @@ impl DocumentType {
 impl DocumentType {
     pub fn set_name(&mut self, maybe_name: Option<&String>) -> &mut Self {
         self.name = if let Some(x) = maybe_name {
-            x.to_owned()
+            DOMString::new(x)
         } else {
-            String::new()
+            Default::default()
         };
         self
     }
@@ -53,9 +55,9 @@ impl DocumentType {
         maybe_pid: Option<&String>,
     ) -> &mut Self {
         self.public_id = if let Some(x) = maybe_pid {
-            x.to_owned()
+            DOMString::new(x)
         } else {
-            String::new()
+            Default::default()
         };
         self
     }
@@ -65,9 +67,9 @@ impl DocumentType {
         maybe_sid: Option<&String>,
     ) -> &mut Self {
         self.system_id = if let Some(x) = maybe_sid {
-            x.to_owned()
+            DOMString::new(x)
         } else {
-            String::new()
+            Default::default()
         };
         self
     }

--- a/dom/node/document_type.rs
+++ b/dom/node/document_type.rs
@@ -7,12 +7,13 @@
 // --------- //
 
 /// Les doctypes ont un nom associé, un ID public et un ID système.
+#[derive(Clone)]
 #[derive(Debug)]
 #[derive(PartialEq)]
 pub struct DocumentType {
-    name: String,
-    public_id: String,
-    system_id: String,
+    pub name: String,
+    pub public_id: String,
+    pub system_id: String,
 }
 
 // -------------- //

--- a/dom/node/element.rs
+++ b/dom/node/element.rs
@@ -118,6 +118,10 @@ impl Element {
         }
     }
 
+    pub fn has_attribute(&self, name: &str) -> bool {
+        self.attributes.borrow().contains_key(name)
+    }
+
     pub fn set_attribute(&self, name: &str, value: &str) {
         if name == "id" {
             *self.id.borrow_mut() = value.to_owned().into();

--- a/dom/node/element.rs
+++ b/dom/node/element.rs
@@ -78,6 +78,12 @@ impl Element {
         self.inner.to_string()
     }
 
+    pub fn tag_name(&self) -> tag_names {
+        self.local_name()
+            .parse()
+            .expect("Devrait être un nom de balise valide")
+    }
+
     pub fn content(
         &self,
     ) -> Option<RwLockReadGuard<DocumentFragmentNode>> {

--- a/dom/node/element.rs
+++ b/dom/node/element.rs
@@ -96,16 +96,15 @@ impl Element {
         None
     }
 
-    pub fn namespace(&self) -> String {
-        self.inner.to_string()
+    pub fn namespace(&self) -> Namespace {
+        self.inner
+            .to_string()
+            .parse()
+            .expect("Devrait être un nom de namespace valide")
     }
 
     pub fn is_in_html_namespace(&self) -> bool {
-        self.namespace()
-            .parse::<Namespace>()
-            .ok()
-            .filter(|ns| Namespace::HTML.eq(ns))
-            .is_some()
+        self.namespace() == Namespace::HTML
     }
 
     // todo: fixme

--- a/dom/node/mod.rs
+++ b/dom/node/mod.rs
@@ -125,6 +125,17 @@ impl Node {
         element.is_mathml_text_integration_point()
     }
 
+    /// Le noeud courant est un document de type [NodeType::COMMENT_NODE].
+    pub fn is_comment(&self) -> bool {
+        self.node_type == NodeType::COMMENT_NODE
+    }
+
+    /// Le noeud courant est un document de type
+    /// [NodeType::DOCUMENT_TYPE_NODE].
+    pub fn is_doctype(&self) -> bool {
+        self.node_type == NodeType::DOCUMENT_TYPE_NODE
+    }
+
     /// Le noeud courant est un document de type [NodeType::DOCUMENT_NODE].
     pub fn is_document(&self) -> bool {
         self.node_type == NodeType::DOCUMENT_NODE

--- a/dom/node/mod.rs
+++ b/dom/node/mod.rs
@@ -29,7 +29,7 @@ mod text;
 /// 4.14. Interface Comment
 mod comment;
 
-use core::cell::RefCell;
+use std::sync::RwLock;
 
 use html_elements::HTMLScriptElement;
 use infra::structure::tree::{TreeNode, TreeNodeWeak};
@@ -53,13 +53,13 @@ pub use self::{
 /// 4.4. Interface Node
 #[derive(Debug)]
 pub struct Node {
-    owner_document: RefCell<Option<TreeNodeWeak<Self>>>,
+    owner_document: RwLock<Option<TreeNodeWeak<Self>>>,
     node_data: Option<NodeData>,
     node_type: NodeType,
 }
 
 pub(crate) struct NodeBuilder {
-    owner_document: RefCell<Option<TreeNodeWeak<Node>>>,
+    owner_document: RwLock<Option<TreeNodeWeak<Node>>>,
     node_data: Option<NodeData>,
     node_type: NodeType,
 }
@@ -186,7 +186,7 @@ impl Node {
     pub fn set_document(&self, document: &TreeNode<Node>) {
         let document_weak: TreeNodeWeak<Node> =
             TreeNodeWeak::from(document);
-        self.owner_document.replace(Some(document_weak));
+        self.owner_document.write().unwrap().replace(document_weak);
     }
 }
 
@@ -227,7 +227,7 @@ impl NodeBuilder {
 
 impl PartialEq for Node {
     fn eq(&self, other: &Self) -> bool {
-        self.node_data == other.node_data
-            && self.node_type == other.node_type
+        self.node_type == other.node_type
+            && self.node_data == other.node_data
     }
 }

--- a/html/elements/scripting/script.rs
+++ b/html/elements/scripting/script.rs
@@ -2,7 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::{borrow::BorrowMut, cell::RefCell};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    RwLock,
+};
 
 use crate::interface::HTMLElementInterface;
 
@@ -11,14 +14,13 @@ use crate::interface::HTMLElementInterface;
 // --------- //
 
 #[derive(Debug)]
-#[derive(PartialEq)]
 pub struct HTMLScriptElement<Document>
 where
     Document: Clone,
 {
-    parser_document: RefCell<Document>,
-    non_blocking: RefCell<bool>,
-    already_started: RefCell<bool>,
+    parser_document: RwLock<Document>,
+    non_blocking: AtomicBool,
+    already_started: AtomicBool,
 }
 
 // -------------- //
@@ -32,17 +34,17 @@ where
     pub const NAME: &'static str = "script";
 
     pub fn set_already_started(&self, to: bool) -> &Self {
-        *self.already_started.borrow_mut() = to;
+        self.already_started.swap(to, Ordering::Relaxed);
         self
     }
 
     pub fn set_non_blocking(&self, to: bool) -> &Self {
-        *self.non_blocking.borrow_mut() = to;
+        self.non_blocking.swap(to, Ordering::Relaxed);
         self
     }
 
     pub fn set_parser_document(&self, parser_document: &D) -> &Self {
-        *self.parser_document.borrow_mut() = parser_document.clone();
+        *self.parser_document.write().unwrap() = parser_document.clone();
         self
     }
 }
@@ -57,5 +59,19 @@ where
 {
     fn tag_name(&self) -> &'static str {
         Self::NAME
+    }
+}
+
+impl<D> PartialEq for HTMLScriptElement<D>
+where
+    D: Clone + PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        *self.parser_document.read().unwrap()
+            == *other.parser_document.read().unwrap()
+            && self.already_started.load(Ordering::Relaxed)
+                == other.already_started.load(Ordering::Relaxed)
+            && self.non_blocking.load(Ordering::Relaxed)
+                == other.non_blocking.load(Ordering::Relaxed)
     }
 }

--- a/html/elements/scripting/template.rs
+++ b/html/elements/scripting/template.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::cell::RefCell;
+use std::sync::RwLock;
 
 use crate::interface::HTMLElementInterface;
 
@@ -12,9 +12,8 @@ use crate::interface::HTMLElementInterface;
 
 #[derive(Debug)]
 #[derive(Default)]
-#[derive(PartialEq)]
 pub struct HTMLTemplateElement<DocumentFragmentNode> {
-    pub content: RefCell<DocumentFragmentNode>,
+    pub content: RwLock<DocumentFragmentNode>,
 }
 
 // -------------- //
@@ -26,7 +25,7 @@ impl<DocumentFragment> HTMLTemplateElement<DocumentFragment> {
 
     pub fn new(content: DocumentFragment) -> Self {
         Self {
-            content: RefCell::new(content),
+            content: RwLock::new(content),
         }
     }
 }
@@ -40,5 +39,16 @@ impl<DocumentFragment> HTMLElementInterface
 {
     fn tag_name(&self) -> &'static str {
         Self::NAME
+    }
+}
+
+impl<DocumentFragment> PartialEq for HTMLTemplateElement<DocumentFragment>
+where
+    DocumentFragment: PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.tag_name() == other.tag_name()
+            && *self.content.read().unwrap()
+                == *other.content.read().unwrap()
     }
 }

--- a/html/parser/error.rs
+++ b/html/parser/error.rs
@@ -636,7 +636,7 @@ mod tests {
             Some(HTMLToken::Tag(HTMLTagToken {
                 name: "div".into(),
                 self_closing_flag: false,
-                self_closing_flag_acknowledge: false,
+                self_closing_flag_acknowledge: Default::default(),
                 attributes: vec![("id".into(), "".into())],
                 is_end: false
             }))
@@ -700,7 +700,7 @@ mod tests {
             Some(HTMLToken::Tag(HTMLTagToken {
                 name: "div".into(),
                 self_closing_flag: false,
-                self_closing_flag_acknowledge: false,
+                self_closing_flag_acknowledge: Default::default(),
                 attributes: vec![],
                 is_end: false
             }))
@@ -802,7 +802,7 @@ mod tests {
             Some(HTMLToken::Tag(HTMLTagToken {
                 name: "div".into(),
                 self_closing_flag: false,
-                self_closing_flag_acknowledge: false,
+                self_closing_flag_acknowledge: Default::default(),
                 attributes: vec![
                     ("id".into(), "foo".into()),
                     ("class".into(), "bar".into())
@@ -861,7 +861,7 @@ mod tests {
                 is_end: false,
                 name: "div".into(),
                 self_closing_flag: false,
-                self_closing_flag_acknowledge: false,
+                self_closing_flag_acknowledge: Default::default(),
                 attributes: vec![("foo<div".into(), "".into())]
             }))
         );
@@ -875,7 +875,7 @@ mod tests {
                 is_end: false,
                 name: "div".into(),
                 self_closing_flag: false,
-                self_closing_flag_acknowledge: false,
+                self_closing_flag_acknowledge: Default::default(),
                 attributes: vec![("id'bar'".into(), "".into())]
             }))
         );
@@ -893,7 +893,7 @@ mod tests {
                 is_end: false,
                 name: "div".into(),
                 self_closing_flag: false,
-                self_closing_flag_acknowledge: false,
+                self_closing_flag_acknowledge: Default::default(),
                 attributes: vec![("foo".into(), "b'ar'".into())]
             }))
         );
@@ -912,7 +912,7 @@ mod tests {
                 is_end: false,
                 name: "div".into(),
                 self_closing_flag: false,
-                self_closing_flag_acknowledge: false,
+                self_closing_flag_acknowledge: Default::default(),
                 attributes: vec![
                     ("foo".into(), "bar".into()),
                     (r#"="baz""#.into(), "".into())
@@ -950,7 +950,7 @@ mod tests {
             Some(HTMLToken::Tag(HTMLTagToken {
                 name: "div".into(),
                 self_closing_flag: false,
-                self_closing_flag_acknowledge: false,
+                self_closing_flag_acknowledge: Default::default(),
                 attributes: vec![("id".into(), "foo".into())],
                 is_end: false
             }))

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -3346,6 +3346,35 @@ where
                 }
             }
 
+            // An end tag whose tag name is one of: "a", "b", "big",
+            // "code", "em", "font", "i", "nobr", "s", "small", "strike",
+            // "strong", "tt", "u"
+            //
+            // Exécuter l'algorithme de l'agence d'adoption pour le jeton.
+            | HTMLToken::Tag(HTMLTagToken {
+                ref name,
+                is_end: true,
+                ..
+            }) if name.is_one_of([
+                tag_names::a,
+                tag_names::b,
+                tag_names::big,
+                tag_names::code,
+                tag_names::em,
+                tag_names::font,
+                tag_names::i,
+                tag_names::nobr,
+                tag_names::s,
+                tag_names::small,
+                tag_names::strike,
+                tag_names::strong,
+                tag_names::tt,
+                tag_names::u,
+            ]) =>
+            {
+                self.run_adoption_agency_algorithm(token.clone());
+            }
+
             // todo: les autres cas de balises de début et de fin
 
             // Any other start tag

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -192,7 +192,9 @@ where
             | InsertionMode::AfterHead => {
                 self.handle_after_head_insertion_mode(token)
             }
-            | InsertionMode::InBody => todo!(),
+            | InsertionMode::InBody => {
+                self.handle_in_body_insertion_mode(token)
+            }
             | InsertionMode::Text => todo!(),
             | InsertionMode::InTable => todo!(),
             | InsertionMode::InTableText => todo!(),
@@ -1725,6 +1727,20 @@ where
                     token,
                 );
             }
+        }
+    }
+
+    fn handle_in_body_insertion_mode(&mut self, token: HTMLToken) {
+        match token {
+            // A character token that is U+0000 NULL
+            //
+            // Erreur d'analyse. Ignorer le jeton.
+            | HTMLToken::Character('\0') => {
+                self.parse_error(token);
+                /* Ignore */
+            }
+
+            | _ => todo!(),
         }
     }
 }

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -3871,7 +3871,35 @@ where
                 self.insert_html_element(tag_token);
             }
 
-            // todo: les autres cas de balises de début et de fin
+            // todo: A start tag whose tag name is one of: "math"
+            // todo: A start tag whose tag name is one of: "svg"
+
+            // A start tag whose tag name is one of: "caption", "col",
+            // "colgroup", "frame", "head", "tbody", "td", "tfoot", "th",
+            // "thead", "tr"
+            //
+            // Erreur d'analyse. Ignorer le token.
+            | HTMLToken::Tag(HTMLTagToken {
+                ref name,
+                is_end: false,
+                ..
+            }) if name.is_one_of([
+                tag_names::caption,
+                tag_names::col,
+                tag_names::colgroup,
+                tag_names::frame,
+                tag_names::head,
+                tag_names::tbody,
+                tag_names::td,
+                tag_names::tfoot,
+                tag_names::th,
+                tag_names::thead,
+                tag_names::tr,
+            ]) =>
+            {
+                self.parse_error(&token);
+                /* Ignore */
+            }
 
             // Any other start tag
             //

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -1884,6 +1884,13 @@ where
                     self.frameset_ok = false;
                 }
             }
+
+            // A comment token
+            //
+            // Insérer un commentaire.
+            | HTMLToken::Comment(comment) => {
+                self.insert_comment(comment);
+            }
             | _ => todo!(),
         }
     }

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -3268,6 +3268,43 @@ where
                 }
             }
 
+            // A start tag whose tag name is one of: "b", "big", "code",
+            // "em", "font", "i", "s", "small", "strike", "strong", "tt",
+            // "u"
+            //
+            // Reconstruire les éléments de mise en forme actifs, s'il y en
+            // a.
+            // Insérez un élément HTML pour le jeton. Pousser cet élément
+            // dans la liste des éléments de formatage actifs.
+            | HTMLToken::Tag(
+                ref tag_token @ HTMLTagToken {
+                    ref name,
+                    is_end: false,
+                    ..
+                },
+            ) if name.is_one_of([
+                tag_names::b,
+                tag_names::big,
+                tag_names::code,
+                tag_names::em,
+                tag_names::font,
+                tag_names::i,
+                tag_names::s,
+                tag_names::small,
+                tag_names::strike,
+                tag_names::strong,
+                tag_names::tt,
+                tag_names::u,
+            ]) =>
+            {
+                self.reconstruct_active_formatting_elements();
+                let element = self.insert_html_element(tag_token);
+                if let Some(element) = element {
+                    self.list_of_active_formatting_elements
+                        .push(Entry::Element(element));
+                }
+            }
+
             // todo: les autres cas de balises de début et de fin
 
             // Any other start tag

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -3375,6 +3375,34 @@ where
                 self.run_adoption_agency_algorithm(token.clone());
             }
 
+            // A start tag whose tag name is one of: "applet", "marquee",
+            // "object"
+            //
+            // Reconstruire les éléments de mise en forme actifs, s'il y en
+            // a.
+            // Insérer un élément HTML pour le jeton.
+            // Insérer un marqueur à la fin de la liste des éléments de
+            // mise en forme actifs.
+            // Définir l'indicateur frameset-ok à "not ok".
+            | HTMLToken::Tag(
+                ref tag_token @ HTMLTagToken {
+                    ref name,
+                    is_end: false,
+                    ..
+                },
+            ) if name.is_one_of([
+                tag_names::applet,
+                tag_names::marquee,
+                tag_names::object,
+            ]) =>
+            {
+                self.reconstruct_active_formatting_elements();
+                self.insert_html_element(tag_token);
+                self.list_of_active_formatting_elements
+                    .push(Entry::Marker);
+                self.frameset_ok_flag = FramesetOkFlag::NotOk;
+            }
+
             // todo: les autres cas de balises de début et de fin
 
             // Any other start tag

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -3733,6 +3733,25 @@ where
                 self.parse_generic_element(tag_token, State::RAWTEXT);
             }
 
+            // A start tag whose tag name is "noembed"
+            // A start tag whose tag name is "noscript", if the scripting
+            // flag is enabled
+            //
+            // Suivre l'algorithme générique d'analyse syntaxique des
+            // éléments de texte brut.
+            | HTMLToken::Tag(
+                ref tag_token @ HTMLTagToken {
+                    ref name,
+                    is_end: false,
+                    ..
+                },
+            ) if tag_names::noembed == name
+                || (tag_names::noscript == name
+                    && self.scripting_enabled) =>
+            {
+                self.parse_generic_element(tag_token, State::RAWTEXT);
+            }
+
             // todo: les autres cas de balises de début et de fin
 
             // Any other start tag

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -3542,7 +3542,10 @@ where
             // correspondance ASCII insensible à la casse pour la chaîne
             // "hidden", alors nous devons mettre le drapeau frameset-ok à
             // "not ok".
-            | HTMLToken::Tag(mut tag_token) => {
+            | HTMLToken::Tag(mut tag_token)
+                if !tag_token.is_end
+                    && tag_names::input == tag_token.name =>
+            {
                 self.reconstruct_active_formatting_elements();
                 self.insert_html_element(&tag_token);
                 self.stack_of_open_elements.pop();

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -1891,6 +1891,14 @@ where
             | HTMLToken::Comment(comment) => {
                 self.insert_comment(comment);
             }
+
+            // A DOCTYPE token
+            //
+            // Erreur d'analyse. Ignorer le jeton.
+            | HTMLToken::DOCTYPE(_) => {
+                self.parse_error(token);
+                /* Ignore */
+            }
             | _ => todo!(),
         }
     }

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -3717,6 +3717,22 @@ where
                 self.parse_generic_element(tag_token, State::RAWTEXT);
             }
 
+            // A start tag whose tag name is "iframe"
+            //
+            // Définir l'indicateur frameset-ok à "not ok".
+            // Suivre l'algorithme générique d'analyse syntaxique des
+            // éléments de texte brut.
+            | HTMLToken::Tag(
+                ref tag_token @ HTMLTagToken {
+                    ref name,
+                    is_end: false,
+                    ..
+                },
+            ) if tag_names::iframe == name => {
+                self.frameset_ok_flag = FramesetOkFlag::NotOk;
+                self.parse_generic_element(tag_token, State::RAWTEXT);
+            }
+
             // todo: les autres cas de balises de début et de fin
 
             // Any other start tag

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -3628,6 +3628,29 @@ where
                 self.frameset_ok_flag = FramesetOkFlag::NotOk;
             }
 
+            // A start tag whose tag name is "image"
+            //
+            // Erreur d'analyse. Changer le nom de balise du jeton en "img"
+            // et puis retraiter (ne demandez pas).
+            | HTMLToken::Tag(
+                ref tag_token @ HTMLTagToken {
+                    ref name,
+                    is_end: false,
+                    ..
+                },
+            ) if tag_names::image == name => {
+                self.parse_error(&token);
+
+                let mut tag_token = tag_token.clone();
+                tag_token.name = tag_names::img.to_string();
+                token = HTMLToken::Tag(tag_token);
+
+                self.process_using_the_rules_for(
+                    self.insertion_mode,
+                    token,
+                );
+            }
+
             // todo: les autres cas de balises de début et de fin
 
             // Any other start tag

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -1930,6 +1930,36 @@ where
                     }
                 });
             }
+
+            // A start tag whose tag name is one of:
+            // "base", "basefont", "bgsound", "link", "meta", "noframes",
+            // "script", "style", "template", "title"
+            // An end tag whose tag name is "template"
+            //
+            // Traiter le jeton en utilisant les règles du mode d'insertion
+            // "in head".
+            | HTMLToken::Tag(HTMLTagToken {
+                ref name, is_end, ..
+            }) if !is_end
+                && name.is_one_of([
+                    tag_names::base,
+                    tag_names::basefont,
+                    tag_names::bgsound,
+                    tag_names::link,
+                    tag_names::meta,
+                    tag_names::noframes,
+                    tag_names::script,
+                    tag_names::style,
+                    tag_names::template,
+                    tag_names::title,
+                ])
+                || is_end && tag_names::template == name =>
+            {
+                self.process_using_the_rules_for(
+                    InsertionMode::InHead,
+                    token,
+                );
+            }
             | _ => todo!(),
         }
     }

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -3784,6 +3784,30 @@ where
                 });
             }
 
+            // A start tag whose tag name is one of: "optgroup", "option"
+            //
+            // Si le nœud actuel est un élément d'option, il est alors
+            // retiré de la pile des éléments ouverts.
+            // Reconstruire les éléments de mise en forme actifs, s'il y en
+            // a.
+            // Insérer un élément HTML pour le jeton.
+            | HTMLToken::Tag(
+                ref tag_token @ HTMLTagToken {
+                    ref name,
+                    is_end: false,
+                    ..
+                },
+            ) if name
+                .is_one_of([tag_names::optgroup, tag_names::option]) =>
+            {
+                let node = self.current_node();
+                if node.element_ref().tag_name() == tag_names::option {
+                    self.stack_of_open_elements.pop();
+                }
+                self.reconstruct_active_formatting_elements();
+                self.insert_html_element(tag_token);
+            }
+
             // todo: les autres cas de balises de début et de fin
 
             // Any other start tag

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -3561,6 +3561,26 @@ where
                 }
             }
 
+            // A start tag whose tag name is one of: "param", "source",
+            // "track"
+            //
+            // Insérer un élément HTML pour le jeton. Retirer immédiatement
+            // le nœud actuel de la pile des éléments ouverts.
+            // Faire savoir que le drapeau self-closing du jeton, s'il est
+            // activé.
+            | HTMLToken::Tag(mut tag_token)
+                if !tag_token.is_end
+                    && tag_token.name.is_one_of([
+                        tag_names::param,
+                        tag_names::source,
+                        tag_names::track,
+                    ]) =>
+            {
+                self.insert_html_element(&tag_token);
+                self.stack_of_open_elements.pop();
+                tag_token.set_acknowledge_self_closing_flag();
+            }
+
             // todo: les autres cas de balises de début et de fin
 
             // Any other start tag

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -218,7 +218,9 @@ where
             | InsertionMode::InSelect => todo!(),
             | InsertionMode::InSelectInTable => todo!(),
             | InsertionMode::InTemplate => todo!(),
-            | InsertionMode::AfterBody => todo!(),
+            | InsertionMode::AfterBody => {
+                self.handle_after_body_insertion_mode(token)
+            }
             | InsertionMode::InFrameset => todo!(),
             | InsertionMode::AfterFrameset => todo!(),
             | InsertionMode::AfterAfterBody => todo!(),
@@ -3283,6 +3285,104 @@ where
             // Any other end tag
             | HTMLToken::Tag(HTMLTagToken { is_end: true, .. }) => {
                 handle_any_other_end_tag(self, &token);
+            }
+        }
+    }
+
+    fn handle_after_body_insertion_mode(&mut self, token: HTMLToken) {
+        match token {
+            // U+0009 CHARACTER TABULATION
+            // U+000A LINE FEED (LF)
+            // U+000C FORM FEED (FF)
+            // U+000D CARRIAGE RETURN (CR)
+            // U+0020 SPACE
+            //
+            // Traiter le jeton en utilisant les règles du mode d'insertion
+            // "in body".
+            | HTMLToken::Character(ch) if ch.is_ascii_whitespace() => {
+                self.process_using_the_rules_for(
+                    InsertionMode::InBody,
+                    token,
+                );
+            }
+
+            // A comment token
+            //
+            // Insérer un commentaire comme dernier enfant du premier
+            // élément de la pile d'éléments ouverts (l'élément html).
+            | HTMLToken::Comment(comment) => {
+                let maybe_insertion_location =
+                    self.stack_of_open_elements.first();
+                if let Some(insertion_location) = maybe_insertion_location
+                {
+                    let comment =
+                        CommentNode::new(&self.document, comment);
+                    insertion_location.append_child(comment.to_owned());
+                }
+            }
+
+            // A DOCTYPE token
+            //
+            // Erreur d'analyse. Ignorer le jeton.
+            | HTMLToken::DOCTYPE(_) => {
+                self.parse_error(token);
+                /* Ignore */
+            }
+
+            // A start tag whose tag name is "html"
+            //
+            // Traiter le jeton en utilisant les règles du mode d'insertion
+            // "in body".
+            | HTMLToken::Tag(HTMLTagToken {
+                ref name,
+                is_end: false,
+                ..
+            }) if tag_names::html == name => {
+                self.process_using_the_rules_for(
+                    InsertionMode::InBody,
+                    token,
+                );
+            }
+
+            // An end tag whose tag name is "html"
+            //
+            // Si l'analyseur a été créé dans le cadre de l'algorithme
+            // d'analyse des fragments HTML, il s'agit d'une erreur
+            // d'analyse ; ignorer le jeton (cas du fragment).
+            // Sinon, nous devons passer le mode d'insertion sur
+            // "after after body".
+            | HTMLToken::Tag(HTMLTagToken {
+                ref name,
+                is_end: true,
+                ..
+            }) if tag_names::html == name => {
+                if self.parsing_fragment {
+                    self.parse_error(token);
+                    return;
+                }
+
+                self.insertion_mode
+                    .switch_to(InsertionMode::AfterAfterBody);
+            }
+
+            // An end-of-file token
+            //
+            // Arrêter l'analyse.
+            | HTMLToken::EOF => {
+                self.stop_parsing = true;
+            }
+
+            // Anything else
+            //
+            // Erreur d'analyse. Passer le mode d'insertion à "in body" et
+            // retraiter le jeton.
+            | _ => {
+                self.parse_error(token.clone());
+                self.insertion_mode.switch_to(InsertionMode::InBody);
+                self.process_using_the_rules_for(
+                    self.insertion_mode,
+                    token,
+                );
             }
         }
     }

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -572,9 +572,9 @@ where
                 } else {
                     let previous_element = self
                         .stack_of_open_elements
-                        .element_immediately_above(table_index);
-                    adjusted_insertion_location.parent =
-                        previous_element.cloned();
+                        .element_immediately_above(table_index)
+                        .map(|(_, p)| p.to_owned());
+                    adjusted_insertion_location.parent = previous_element;
                 }
             }
         } else {
@@ -965,9 +965,9 @@ where
             let last = index == 0;
 
             let node = if last && self.parsing_fragment {
-                self.context_element.clone().unwrap()
+                self.context_element.to_owned().unwrap()
             } else {
-                node.clone()
+                node.to_owned()
             };
 
             let element = node.element_ref();
@@ -1253,7 +1253,7 @@ where
                 let element = self
                     .create_element_for(tag_token, Namespace::HTML, None)
                     .expect("Un élément DOM HTMLHtmlElement");
-                self.document.append_child(element.clone());
+                self.document.append_child(element.to_owned());
                 self.stack_of_open_elements.put(element);
                 self.insertion_mode.switch_to(InsertionMode::BeforeHead);
             }
@@ -1293,7 +1293,7 @@ where
                 )
                 .expect("Un élément DOM HTMLHtmlElement");
                 element.set_document(self.document.deref());
-                self.document.append_child(element.clone());
+                self.document.append_child(element.to_owned());
                 self.stack_of_open_elements.put(element);
                 self.insertion_mode.switch_to(InsertionMode::BeforeHead);
                 self.process_using_the_rules_for(
@@ -1852,7 +1852,7 @@ where
             {
                 self.parse_error(&token);
                 if let Some(head) = self.head_element.as_ref() {
-                    self.stack_of_open_elements.put(head.clone());
+                    self.stack_of_open_elements.put(head.to_owned());
                 }
                 self.process_using_the_rules_for(
                     InsertionMode::InHead,
@@ -3642,7 +3642,7 @@ where
             ) if tag_names::image == name => {
                 self.parse_error(&token);
 
-                let mut tag_token = tag_token.clone();
+                let mut tag_token = tag_token.to_owned();
                 tag_token.name = tag_names::img.to_string();
                 token = HTMLToken::Tag(tag_token);
 
@@ -4131,7 +4131,7 @@ mod tests {
         let mut parser = test_the_str!("<!-- Comment -->");
         let token = parser.tokenizer.next_token().unwrap();
         parser.handle_initial_insertion_mode(token);
-        let node = parser.document.get_first_child().clone().unwrap();
+        let node = parser.document.get_first_child().to_owned().unwrap();
         assert!(node.is_comment());
         assert!(!node.is_document());
 
@@ -4141,7 +4141,7 @@ mod tests {
         let token = parser.tokenizer.next_token().unwrap();
         parser.handle_initial_insertion_mode(token);
         let doc = parser.document.document_ref();
-        let doctype = doc.get_doctype().clone().unwrap();
+        let doctype = doc.get_doctype().to_owned().unwrap();
         assert_eq!(doctype.name.to_string(), "html".to_string());
         assert_eq!(doctype.public_id.to_string(), "".to_string());
         assert_eq!(doctype.system_id.to_string(), "".to_string());
@@ -4163,7 +4163,7 @@ mod tests {
         let mut parser = test_the_str!("<!-- comment -->");
         let token = parser.tokenizer.next_token().unwrap();
         parser.handle_before_html_insertion_mode(token);
-        let doc = parser.document.get_first_child().clone().unwrap();
+        let doc = parser.document.get_first_child().to_owned().unwrap();
         assert!(doc.is_comment());
 
         // Tag
@@ -4172,7 +4172,7 @@ mod tests {
         // <html>
         let token = parser.tokenizer.next_token().unwrap();
         parser.handle_before_html_insertion_mode(token);
-        let doc = parser.document.get_first_child().clone().unwrap();
+        let doc = parser.document.get_first_child().to_owned().unwrap();
         assert_eq!(tag_names::html, doc.element_ref().local_name());
         assert_eq!(parser.insertion_mode, InsertionMode::BeforeHead);
 
@@ -4180,7 +4180,7 @@ mod tests {
 
         let token = parser.tokenizer.next_token().unwrap();
         parser.handle_before_html_insertion_mode(token);
-        let doc = parser.document.get_last_child().clone().unwrap();
+        let doc = parser.document.get_last_child().to_owned().unwrap();
         assert_eq!(tag_names::html, doc.element_ref().local_name());
         assert_ne!(tag_names::head, doc.element_ref().local_name());
     }

--- a/html/parser/state.rs
+++ b/html/parser/state.rs
@@ -114,6 +114,12 @@ impl StackOfOpenElements {
         })
     }
 
+    pub fn has_element_with_tag_name(&self, tag_name: tag_names) -> bool {
+        self.elements
+            .iter()
+            .any(|element| tag_name == element.element_ref().local_name())
+    }
+
     pub fn element_immediately_above(
         &self,
         node_index: usize,

--- a/html/parser/state.rs
+++ b/html/parser/state.rs
@@ -186,6 +186,26 @@ impl StackOfOpenElements {
     pub fn put(&mut self, element: TreeNode<Node>) {
         self.elements.push(element);
     }
+
+    // <https://github.com/rust-lang/rust/issues/83701>
+    pub fn scoped_elements_with<const N: usize>(
+        list: impl IntoIterator<Item = tag_names>,
+    ) -> [tag_names; N] {
+        let mut elements: [tag_names; N] = [tag_names::var; N];
+
+        Self::SCOPE_ELEMENTS
+            .into_iter()
+            .enumerate()
+            .for_each(|(i, t)| {
+                elements[i] = t;
+            });
+
+        list.into_iter().enumerate().for_each(|(i, t)| {
+            elements[i] = t;
+        });
+
+        elements
+    }
 }
 
 impl ListOfActiveFormattingElements {

--- a/html/parser/state.rs
+++ b/html/parser/state.rs
@@ -78,28 +78,10 @@ impl InsertionMode {
 }
 
 impl StackOfOpenElements {
-    /// Taille du vecteur de noeuds d'éléments.
-    pub fn len(&self) -> usize {
-        self.elements.len()
-    }
 
     /// Le nœud actuel est le nœud le plus bas de cette pile d'éléments
     /// ouverts.
     pub fn current_node(&self) -> Option<&TreeNode<Node>> {
-        self.elements.last()
-    }
-
-    /// Vérifie si le vecteur de noeuds d'éléments est vide.
-    pub fn is_empty(&self) -> bool {
-        self.elements.is_empty()
-    }
-
-    /// Premier élément du vecteur de noeuds d'éléments.
-    pub fn first(&self) -> Option<&TreeNode<Node>> {
-        self.elements.first()
-    }
-
-    pub fn last(&self) -> Option<&TreeNode<Node>> {
         self.elements.last()
     }
 
@@ -125,11 +107,6 @@ impl StackOfOpenElements {
         node_index: usize,
     ) -> Option<&TreeNode<Node>> {
         self.elements.get(node_index - 1)
-    }
-
-    /// Retire le dernier élément du vecteur de noeud.
-    pub fn pop(&mut self) -> Option<TreeNode<Node>> {
-        self.elements.pop()
     }
 
     pub fn pop_until_tag(&mut self, tag_name: tag_names) {
@@ -232,6 +209,21 @@ impl Default for InsertionMode {
         Self::Initial
     }
 }
+
+impl ops::Deref for StackOfOpenElements {
+    type Target = Vec<TreeNode<Node>>;
+
+    fn deref(&self) -> &Self::Target {
+        self.elements.as_ref()
+    }
+}
+
+impl ops::DerefMut for StackOfOpenElements {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.elements.as_mut()
+    }
+}
+
 impl ops::Deref for ListOfActiveFormattingElements {
     type Target = Vec<Entry>;
 

--- a/html/parser/state.rs
+++ b/html/parser/state.rs
@@ -135,11 +135,6 @@ impl StackOfOpenElements {
         tag_name: tag_names,
         list: [tag_names; N],
     ) -> bool {
-        let tag_name: tag_names = tag_name
-            .try_into()
-            .ok()
-            .expect("Devrait être un nom de balise valide.");
-
         self.elements.iter().rev().any(|node| {
             let element = node.element_ref();
             let name = element.local_name();

--- a/html/parser/state.rs
+++ b/html/parser/state.rs
@@ -78,6 +78,36 @@ impl InsertionMode {
 }
 
 impl StackOfOpenElements {
+    ///   - applet
+    ///   - caption
+    ///   - html
+    ///   - table
+    ///   - td
+    ///   - th
+    ///   - marquee
+    ///   - object
+    ///   - template
+    ///   - MathML mi
+    ///   - MathML mo
+    ///   - MathML mn
+    ///   - MathML ms
+    ///   - MathML mtext
+    ///   - MathML annotation-xml
+    ///   - SVG foreignObject
+    ///   - SVG desc
+    ///   - SVG title
+    pub const SCOPE_ELEMENTS: [tag_names; 9] = [
+        tag_names::applet,
+        tag_names::caption,
+        tag_names::html,
+        tag_names::table,
+        tag_names::td,
+        tag_names::th,
+        tag_names::marquee,
+        tag_names::object,
+        tag_names::template,
+        // todo: ajouter les éléments manquants MathML & SVG
+    ];
 
     /// Le nœud actuel est le nœud le plus bas de cette pile d'éléments
     /// ouverts.
@@ -93,6 +123,23 @@ impl StackOfOpenElements {
     ) -> Option<(usize, &TreeNode<Node>)> {
         self.elements.iter().enumerate().rfind(|(_, element)| {
             tag_name == element.element_ref().local_name()
+        })
+    }
+
+    /// On dit que la pile d'éléments ouverts a un élément particulier dans
+    /// son champ d'application lorsqu'elle a cet élément dans le champ
+    /// d'application spécifique composé des types d'éléments suivants :
+    /// Voir la constante: [Self::SCOPE_ELEMENTS].
+    pub fn has_element_in_scope<const N: usize>(
+        &self,
+        tag_name: tag_names,
+        list: [tag_names; N],
+    ) -> bool {
+        self.elements.iter().rev().any(|node| {
+            let element = node.element_ref();
+            let name = element.local_name();
+            tag_name == name
+                || !list.into_iter().any(|tag_name| tag_name == name)
         })
     }
 

--- a/html/parser/state.rs
+++ b/html/parser/state.rs
@@ -135,6 +135,11 @@ impl StackOfOpenElements {
         tag_name: tag_names,
         list: [tag_names; N],
     ) -> bool {
+        let tag_name: tag_names = tag_name
+            .try_into()
+            .ok()
+            .expect("Devrait être un nom de balise valide.");
+
         self.elements.iter().rev().any(|node| {
             let element = node.element_ref();
             let name = element.local_name();

--- a/html/parser/token.rs
+++ b/html/parser/token.rs
@@ -436,22 +436,16 @@ impl HTMLDoctypeToken {
 // --------- //
 
 impl HTMLToken {
-    pub fn into_start_tag(&mut self) -> &mut HTMLTagToken {
-        assert!(matches!(
-            self,
-            Self::Tag(HTMLTagToken { is_end: false, .. })
-        ));
+    pub fn as_tag(&self) -> &HTMLTagToken {
+        assert!(matches!(self, Self::Tag(HTMLTagToken { .. })));
         if let Self::Tag(tag) = self {
             return tag;
         }
         unreachable!()
     }
 
-    pub fn into_end_tag(&mut self) -> &mut HTMLTagToken {
-        assert!(matches!(
-            self,
-            Self::Tag(HTMLTagToken { is_end: true, .. })
-        ));
+    pub fn as_tag_mut(&mut self) -> &mut HTMLTagToken {
+        assert!(matches!(self, Self::Tag(HTMLTagToken { .. })));
         if let Self::Tag(tag) = self {
             return tag;
         }
@@ -568,6 +562,11 @@ impl HTMLTagToken {
         if *self_closing_flag {
             *self_closing_flag_acknowledge = true;
         }
+    }
+
+    pub fn tag_name(&self) -> tag_names {
+        let Self { name, .. } = self;
+        name.parse().expect("Devrait être un nom de balise valide")
     }
 }
 

--- a/html/parser/token.rs
+++ b/html/parser/token.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::sync::RwLock;
+
 use dom::node::QuirksMode;
 use html_elements::{
     interface::IsOneOfAttributesInterface, tag_attributes,
@@ -45,12 +47,10 @@ pub struct HTMLDoctypeToken {
 ///   - une liste d'attributs: chacun d'entre eux ayant un nom et une
 ///     valeur.
 #[derive(Debug)]
-#[derive(Clone)]
-#[derive(PartialEq)]
 pub struct HTMLTagToken {
     pub name: String,
     pub self_closing_flag: bool,
-    pub self_closing_flag_acknowledge: bool,
+    pub self_closing_flag_acknowledge: RwLock<bool>,
     pub attributes: Vec<HTMLTagAttribute>,
     pub is_end: bool,
 }
@@ -486,7 +486,7 @@ impl HTMLTagToken {
         Self {
             name: String::new(),
             self_closing_flag: false,
-            self_closing_flag_acknowledge: false,
+            self_closing_flag_acknowledge: RwLock::new(false),
             attributes: vec![],
             is_end: false,
         }
@@ -500,7 +500,7 @@ impl HTMLTagToken {
         Self {
             name: String::new(),
             self_closing_flag: false,
-            self_closing_flag_acknowledge: false,
+            self_closing_flag_acknowledge: RwLock::new(false),
             attributes: vec![],
             is_end: true,
         }
@@ -553,14 +553,14 @@ impl HTMLTagToken {
         *self_closing_flag = to;
     }
 
-    pub fn set_acknowledge_self_closing_flag(&mut self) {
+    pub fn set_acknowledge_self_closing_flag(&self) {
         let Self {
             self_closing_flag,
             self_closing_flag_acknowledge,
             ..
         } = self;
         if *self_closing_flag {
-            *self_closing_flag_acknowledge = true;
+            *self_closing_flag_acknowledge.write().unwrap() = true;
         }
     }
 
@@ -601,5 +601,33 @@ impl HTMLToken {
         } else {
             false
         }
+    }
+}
+
+// -------------- //
+// Implémentation // -> Interface
+// -------------- //
+
+impl Clone for HTMLTagToken {
+    fn clone(&self) -> Self {
+        Self {
+            name: self.name.clone(),
+            self_closing_flag: self.self_closing_flag,
+            self_closing_flag_acknowledge: RwLock::from(
+                *self.self_closing_flag_acknowledge.read().unwrap(),
+            ),
+            attributes: self.attributes.clone(),
+            is_end: self.is_end,
+        }
+    }
+}
+impl PartialEq for HTMLTagToken {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name
+            && self.self_closing_flag == other.self_closing_flag
+            && *self.self_closing_flag_acknowledge.read().unwrap()
+                == *other.self_closing_flag_acknowledge.read().unwrap()
+            && self.attributes == other.attributes
+            && self.is_end == other.is_end
     }
 }

--- a/html/parser/tokenizer.rs
+++ b/html/parser/tokenizer.rs
@@ -4742,7 +4742,7 @@ mod tests {
             Some(HTMLToken::Tag(HTMLTagToken {
                 name: "a".into(),
                 self_closing_flag: false,
-                self_closing_flag_acknowledge: false,
+                self_closing_flag_acknowledge: Default::default(),
                 attributes: vec![(
                     "href".into(),
                     "?a=b&c=d&a0b=c&copy=1&noti=n&not=in&notin=&notin;&not;&;& &".into()
@@ -4774,7 +4774,7 @@ mod tests {
             Some(HTMLToken::Tag(HTMLTagToken {
                 name: "div".into(),
                 self_closing_flag: false,
-                self_closing_flag_acknowledge: false,
+                self_closing_flag_acknowledge: Default::default(),
                 attributes: vec![("id".into(), "foo".into())],
                 is_end: false
             }))
@@ -4788,7 +4788,7 @@ mod tests {
             Some(HTMLToken::Tag(HTMLTagToken {
                 name: "input".into(),
                 self_closing_flag: true,
-                self_closing_flag_acknowledge: false,
+                self_closing_flag_acknowledge: Default::default(),
                 attributes: vec![("value".into(), "Hello World".into())],
                 is_end: false
             }))

--- a/html/parser/tokenizer.rs
+++ b/html/parser/tokenizer.rs
@@ -424,7 +424,7 @@ where
     C: Iterator<Item = CodePoint>,
 {
     pub fn current_token(&mut self) -> Option<HTMLToken> {
-        if let Some(token) = self.token.clone() {
+        if let Some(token) = self.token.to_owned() {
             self.output_tokens.push_back(token);
         }
         self.pop_token()
@@ -508,7 +508,7 @@ where
 
     fn flush_temporary_buffer(&mut self) -> &mut Self {
         if self.state.is_character_of_attribute() {
-            self.temporary_buffer.clone().chars().for_each(|ch| {
+            self.temporary_buffer.to_owned().chars().for_each(|ch| {
                 self.change_current_token(|token| {
                     token
                         .as_tag_mut()
@@ -557,7 +557,7 @@ impl HTMLTokenizerState {
         let mut to: Cow<str> = Cow::default();
 
         if state == "return-state" {
-            if let Some(return_state) = self.returns.clone() {
+            if let Some(return_state) = self.returns.to_owned() {
                 to = Cow::from(return_state.to_string());
             }
         } else {

--- a/html/parser/tokenizer.rs
+++ b/html/parser/tokenizer.rs
@@ -511,7 +511,7 @@ where
             self.temporary_buffer.clone().chars().for_each(|ch| {
                 self.change_current_token(|token| {
                     token
-                        .into_start_tag()
+                        .as_tag_mut()
                         .append_character_to_attribute_value(ch);
                 });
             });
@@ -2065,9 +2065,7 @@ where
                 .change_current_token(|token| {
                     let mut attribute = HTMLTagAttribute::default();
                     attribute.0 = HTMLTagAttributeName::from(ch);
-                    token
-                        .into_start_tag()
-                        .define_tag_attributes(attribute);
+                    token.as_tag_mut().define_tag_attributes(attribute);
                 })
                 .switch_state_to("attribute-name")
                 .and_emit_with_error(
@@ -2083,9 +2081,7 @@ where
             | Some(_) => self
                 .change_current_token(|token| {
                     let attribute = HTMLTagAttribute::default();
-                    token
-                        .into_start_tag()
-                        .define_tag_attributes(attribute);
+                    token.as_tag_mut().define_tag_attributes(attribute);
                 })
                 .reconsume("attribute-name")
                 .and_continue(),
@@ -2127,11 +2123,9 @@ where
             // l'attribut actuel.
             | Some(ch) if ch.is_ascii_uppercase() => self
                 .change_current_token(|token| {
-                    token
-                        .into_start_tag()
-                        .append_character_to_attribute_name(
-                            ch.to_ascii_lowercase(),
-                        );
+                    token.as_tag_mut().append_character_to_attribute_name(
+                        ch.to_ascii_lowercase(),
+                    );
                 })
                 .and_continue(),
 
@@ -2161,7 +2155,7 @@ where
             | Some(ch) => {
                 self.change_current_token(|token| {
                     token
-                        .into_start_tag()
+                        .as_tag_mut()
                         .append_character_to_attribute_name(ch);
                 });
 
@@ -2225,9 +2219,7 @@ where
             | Some(_) => self
                 .change_current_token(|token| {
                     let attribute = HTMLTagAttribute::default();
-                    token
-                        .into_start_tag()
-                        .define_tag_attributes(attribute);
+                    token.as_tag_mut().define_tag_attributes(attribute);
                 })
                 .reconsume("attribute-name")
                 .and_continue(),
@@ -2324,7 +2316,7 @@ where
             | Some('\0') => self
                 .change_current_token(|token| {
                     token
-                        .into_start_tag()
+                        .as_tag_mut()
                         .append_character_to_attribute_value(
                             char::REPLACEMENT_CHARACTER,
                         );
@@ -2346,7 +2338,7 @@ where
             | Some(ch) => self
                 .change_current_token(|token| {
                     token
-                        .into_start_tag()
+                        .as_tag_mut()
                         .append_character_to_attribute_value(ch);
                 })
                 .and_continue(),
@@ -2392,7 +2384,7 @@ where
             | Some('\0') => self
                 .change_current_token(|token| {
                     token
-                        .into_start_tag()
+                        .as_tag_mut()
                         .append_character_to_attribute_value(
                             char::REPLACEMENT_CHARACTER,
                         );
@@ -2424,7 +2416,7 @@ where
             | Some(ch) => {
                 self.change_current_token(|token| {
                     token
-                        .into_start_tag()
+                        .as_tag_mut()
                         .append_character_to_attribute_value(ch);
                 });
 
@@ -2498,7 +2490,7 @@ where
             // vrai. Passer à l'état `data`. Émettre le jeton actuel.
             | Some('>') => self
                 .change_current_token(|token| {
-                    token.into_start_tag().set_self_closing_tag(true);
+                    token.as_tag_mut().set_self_closing_tag(true);
                 })
                 .switch_state_to("data")
                 .and_emit(),
@@ -4179,7 +4171,7 @@ where
                 if self.state.is_character_of_attribute() {
                     self.change_current_token(|token| {
                         token
-                            .into_start_tag()
+                            .as_tag_mut()
                             .append_character_to_attribute_value(ch);
                     })
                     .and_continue()

--- a/infra/Cargo.toml
+++ b/infra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-infra"
-version = "0.1.2"
+version = "0.1.3"
 license-file = "../LICENSE"
 edition = "2021"
 

--- a/infra/Cargo.toml
+++ b/infra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-infra"
-version = "0.1.1"
+version = "0.1.2"
 license-file = "../LICENSE"
 edition = "2021"
 

--- a/infra/primitive/mod.rs
+++ b/infra/primitive/mod.rs
@@ -3,3 +3,4 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 pub mod codepoint;
+pub mod string;

--- a/infra/primitive/string.rs
+++ b/infra/primitive/string.rs
@@ -1,0 +1,75 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use core::fmt;
+use std::{
+    hash,
+    sync::{RwLock, RwLockReadGuard},
+};
+
+// --------- //
+// Structure //
+// --------- //
+
+#[derive(Debug)]
+#[derive(Default)]
+pub struct DOMString {
+    inner: RwLock<String>,
+}
+
+// -------------- //
+// Implémentation //
+// -------------- //
+
+impl DOMString {
+    pub fn new(s: impl ToString) -> Self {
+        Self {
+            inner: RwLock::new(s.to_string()),
+        }
+    }
+
+    pub fn read(&self) -> RwLockReadGuard<String> {
+        self.inner.read().unwrap()
+    }
+
+    pub fn write(&self, data: Self) {
+        self.inner
+            .write()
+            .unwrap()
+            .clone_from(&data.inner.read().unwrap());
+    }
+}
+
+// -------------- //
+// Implémentation // -> Interface
+// -------------- //
+
+impl PartialEq for DOMString {
+    fn eq(&self, other: &Self) -> bool {
+        *self.read() == *other.read()
+    }
+}
+
+impl Eq for DOMString {}
+
+impl hash::Hash for DOMString {
+    fn hash<H: hash::Hasher>(&self, state: &mut H) {
+        self.read().hash(state);
+    }
+}
+
+impl Clone for DOMString {
+    fn clone(&self) -> Self {
+        let s = self.read().clone();
+        Self {
+            inner: RwLock::new(s),
+        }
+    }
+}
+
+impl fmt::Display for DOMString {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.read())
+    }
+}

--- a/infra/structure/lists/queue.rs
+++ b/infra/structure/lists/queue.rs
@@ -96,7 +96,7 @@ where
         Option::from(
             self.peek_range(0..lookahead_offset)
                 .iter()
-                .filter_map(|mch| mch.clone())
+                .filter_map(|mch| mch.to_owned())
                 .collect::<R>(),
         )
     }
@@ -105,7 +105,7 @@ where
         self.fill_queue_max();
         self.queue.as_slice()[0..]
             .iter()
-            .filter_map(|mch| mch.clone())
+            .filter_map(|mch| mch.to_owned())
             .collect::<R>()
     }
 

--- a/infra/structure/tree/mod.rs
+++ b/infra/structure/tree/mod.rs
@@ -93,7 +93,7 @@ impl<T> TreeNode<T> {
 
         if let Some(next_node) = self.next_sibling() {
             *next_node.prev_sibling.write().unwrap() =
-                self.prev_sibling.write().unwrap().clone();
+                self.prev_sibling.write().unwrap().to_owned();
         }
 
         if let Some(parent) = self.parent_node() {
@@ -152,7 +152,7 @@ impl<T> TreeNode<T> {
                         .next_sibling
                         .write()
                         .unwrap()
-                        .replace(child.clone());
+                        .replace(child.to_owned());
                     child
                         .prev_sibling
                         .write()
@@ -163,14 +163,14 @@ impl<T> TreeNode<T> {
                     self.first_child
                         .write()
                         .unwrap()
-                        .replace(child.clone());
+                        .replace(child.to_owned());
                 }
             }
         }
     }
 
     pub fn next_sibling(&self) -> Option<Self> {
-        self.next_sibling.read().unwrap().clone()
+        self.next_sibling.read().unwrap().to_owned()
     }
 
     /// Un objet qui participe à un arbre a un parent, qui est soit null

--- a/infra/structure/tree/mod.rs
+++ b/infra/structure/tree/mod.rs
@@ -6,11 +6,10 @@ mod node;
 mod weak;
 
 use core::ops;
-use std::{cell::Ref, rc::Rc};
-
-pub use weak::TreeNodeWeak;
+use std::sync::{Arc, RwLockReadGuard};
 
 use self::node::Node;
+pub use self::weak::TreeNodeWeak;
 
 // --------- //
 // Structure //
@@ -21,7 +20,7 @@ use self::node::Node;
 #[derive(Debug)]
 #[derive(PartialEq)]
 pub struct TreeNode<T> {
-    node_ref: Rc<Node<T>>,
+    node_ref: Arc<Node<T>>,
 }
 
 // -------------- //
@@ -31,12 +30,12 @@ pub struct TreeNode<T> {
 impl<T> TreeNode<T> {
     pub fn new(data: T) -> Self {
         Self {
-            node_ref: Rc::new(Node::new(data)),
+            node_ref: Arc::new(Node::new(data)),
         }
     }
 
-    fn new_node(rc: Rc<Node<T>>) -> Self {
-        Self { node_ref: rc }
+    fn new_node(arc: Arc<Node<T>>) -> Self {
+        Self { node_ref: arc }
     }
 
     /// Pour ajouter un noeud à un parent, il faut pré-insérer le noeud
@@ -54,37 +53,47 @@ impl<T> TreeNode<T> {
     pub fn append_child(&self, node: impl Into<Self>) {
         let child: Self = node.into();
 
-        assert!(child.parent.borrow().is_none());
+        assert!(child.parent.read().unwrap().is_none());
 
         if let Some(last_node) = self.get_last_child().as_ref() {
             last_node
                 .next_sibling
-                .borrow_mut()
+                .write()
+                .unwrap()
                 .replace(child.to_owned());
 
             child
                 .prev_sibling
-                .replace(TreeNodeWeak::from(&child).into());
+                .write()
+                .unwrap()
+                .replace(TreeNodeWeak::from(&child));
         }
 
-        child.parent.borrow_mut().replace(TreeNodeWeak::from(self));
+        child
+            .parent
+            .write()
+            .unwrap()
+            .replace(TreeNodeWeak::from(self));
 
         if self.get_first_child().is_none() {
-            self.first_child.replace(child.to_owned().into());
+            self.first_child.write().unwrap().replace(child.to_owned());
         }
 
-        self.last_child.replace(child.into());
+        self.last_child.write().unwrap().replace(child);
     }
 
     pub fn detach_node(&self) {
         if let Some(prev_node) = self.previous_sibling() {
-            prev_node.next_sibling.replace(self.next_sibling());
+            prev_node
+                .next_sibling
+                .write()
+                .unwrap()
+                .replace(self.next_sibling().unwrap());
         }
 
         if let Some(next_node) = self.next_sibling() {
-            next_node
-                .prev_sibling
-                .replace(self.prev_sibling.borrow().clone());
+            *next_node.prev_sibling.write().unwrap() =
+                self.prev_sibling.write().unwrap().clone();
         }
 
         if let Some(parent) = self.parent_node() {
@@ -97,26 +106,34 @@ impl<T> TreeNode<T> {
                 .to_owned()
                 .expect("Le dernier enfant");
 
-            if Rc::ptr_eq(self, &first_child) {
-                parent.first_child.replace(self.next_sibling());
-            } else if Rc::ptr_eq(self, &last_child) {
-                parent.last_child.replace(self.previous_sibling());
+            if Arc::ptr_eq(self, &first_child) {
+                parent
+                    .first_child
+                    .write()
+                    .unwrap()
+                    .replace(self.next_sibling().unwrap());
+            } else if Arc::ptr_eq(self, &last_child) {
+                parent
+                    .last_child
+                    .write()
+                    .unwrap()
+                    .replace(self.previous_sibling().unwrap());
             }
         }
 
-        self.parent.replace(None);
-        self.prev_sibling.replace(None);
-        self.next_sibling.replace(None);
+        *self.parent.write().unwrap() = None;
+        *self.prev_sibling.write().unwrap() = None;
+        *self.next_sibling.write().unwrap() = None;
     }
 
     /// Récupère le premier enfant de l'arbre.
-    pub fn get_first_child(&self) -> Ref<'_, Option<TreeNode<T>>> {
-        self.first_child.borrow()
+    pub fn get_first_child(&self) -> RwLockReadGuard<Option<TreeNode<T>>> {
+        self.first_child.read().unwrap()
     }
 
     /// Récupère le dernier enfant de l'arbre.
-    pub fn get_last_child(&self) -> Ref<'_, Option<TreeNode<T>>> {
-        self.last_child.borrow()
+    pub fn get_last_child(&self) -> RwLockReadGuard<Option<TreeNode<T>>> {
+        self.last_child.read().unwrap()
     }
 
     pub fn insert_before(&self, node: Self, maybe_child: Option<&Self>) {
@@ -125,40 +142,57 @@ impl<T> TreeNode<T> {
             return;
         }
 
-        assert!(node.parent.borrow().is_none());
+        assert!(node.parent.read().unwrap().is_none());
 
         if let Some(child) = maybe_child {
-            child.parent.replace(Some(self.into()));
+            child.parent.write().unwrap().replace(self.into());
             match child.previous_sibling() {
                 | Some(prev_sibling) => {
-                    prev_sibling.next_sibling.replace(Some(child.clone()));
-                    child.prev_sibling.replace(Some(prev_sibling.into()));
+                    prev_sibling
+                        .next_sibling
+                        .write()
+                        .unwrap()
+                        .replace(child.clone());
+                    child
+                        .prev_sibling
+                        .write()
+                        .unwrap()
+                        .replace(prev_sibling.into());
                 }
                 | None => {
-                    self.first_child.replace(Some(child.clone()));
+                    self.first_child
+                        .write()
+                        .unwrap()
+                        .replace(child.clone());
                 }
             }
         }
     }
 
     pub fn next_sibling(&self) -> Option<Self> {
-        self.next_sibling.borrow().clone()
+        self.next_sibling.read().unwrap().clone()
     }
 
     /// Un objet qui participe à un arbre a un parent, qui est soit null
     /// soit un objet.
     pub fn parent_node(&self) -> Option<Self> {
-        self.parent.borrow().as_deref().and_then(|node_weak| {
-            node_weak.upgrade().map(|node_ref| node_ref.into())
-        })
+        self.parent
+            .read()
+            .unwrap()
+            .as_deref()
+            .and_then(|node_weak| {
+                node_weak.upgrade().map(|node_ref| node_ref.into())
+            })
     }
 
     /// Le frère précédent d'un objet est son premier frère précédent ou
     /// null s'il n'a pas de frère précédent.
     pub fn previous_sibling(&self) -> Option<Self> {
-        self.prev_sibling.borrow().as_deref().and_then(|node_weak| {
-            node_weak.upgrade().map(|node_ref| node_ref.into())
-        })
+        self.prev_sibling.read().unwrap().as_deref().and_then(
+            |node_weak| {
+                node_weak.upgrade().map(|node_ref| node_ref.into())
+            },
+        )
     }
 }
 
@@ -166,8 +200,8 @@ impl<T> TreeNode<T> {
 // Implémentation // -> Interface
 // -------------- //
 
-impl<T> From<Rc<Node<T>>> for TreeNode<T> {
-    fn from(rc: Rc<Node<T>>) -> Self {
+impl<T> From<Arc<Node<T>>> for TreeNode<T> {
+    fn from(rc: Arc<Node<T>>) -> Self {
         Self::new_node(rc)
     }
 }
@@ -179,7 +213,7 @@ impl<T> Clone for TreeNode<T> {
 }
 
 impl<T> ops::Deref for TreeNode<T> {
-    type Target = Rc<Node<T>>;
+    type Target = Arc<Node<T>>;
 
     fn deref(&self) -> &Self::Target {
         &self.node_ref

--- a/infra/structure/tree/mod.rs
+++ b/infra/structure/tree/mod.rs
@@ -126,6 +126,17 @@ impl<T> TreeNode<T> {
         *self.next_sibling.write().unwrap() = None;
     }
 
+    pub fn foreach_child<F>(&self, mut f: F)
+    where
+        F: FnMut(&Self),
+    {
+        let mut current_node = self.get_first_child().to_owned();
+        while let Some(node) = current_node {
+            f(&node);
+            current_node = node.next_sibling().to_owned();
+        }
+    }
+
     /// Récupère le premier enfant de l'arbre.
     pub fn get_first_child(&self) -> RwLockReadGuard<Option<TreeNode<T>>> {
         self.first_child.read().unwrap()

--- a/infra/structure/tree/node.rs
+++ b/infra/structure/tree/node.rs
@@ -2,8 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use core::{borrow::Borrow, ops};
-use std::{borrow::BorrowMut, cell::RefCell};
+use core::ops;
+use std::{
+    borrow::{Borrow, BorrowMut},
+    sync::RwLock,
+};
 
 use super::{TreeNode, TreeNodeWeak};
 
@@ -15,13 +18,13 @@ use super::{TreeNode, TreeNodeWeak};
 pub struct Node<T> {
     data: T,
 
-    pub(crate) parent: RefCell<Option<TreeNodeWeak<T>>>,
+    pub(crate) parent: RwLock<Option<TreeNodeWeak<T>>>,
 
-    pub(crate) first_child: RefCell<Option<TreeNode<T>>>,
-    pub(crate) last_child: RefCell<Option<TreeNode<T>>>,
+    pub(crate) first_child: RwLock<Option<TreeNode<T>>>,
+    pub(crate) last_child: RwLock<Option<TreeNode<T>>>,
 
-    pub(crate) prev_sibling: RefCell<Option<TreeNodeWeak<T>>>,
-    pub(crate) next_sibling: RefCell<Option<TreeNode<T>>>,
+    pub(crate) prev_sibling: RwLock<Option<TreeNodeWeak<T>>>,
+    pub(crate) next_sibling: RwLock<Option<TreeNode<T>>>,
 }
 
 // ----------- //

--- a/infra/structure/tree/weak.rs
+++ b/infra/structure/tree/weak.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use core::ops;
-use std::rc::{Rc, Weak};
+use std::sync::{Arc, Weak};
 
 use super::{node::Node, TreeNode};
 
@@ -51,13 +51,13 @@ impl<T> ops::Deref for TreeNodeWeak<T> {
 }
 
 impl<T> From<&TreeNode<T>> for TreeNodeWeak<T> {
-    fn from(rc: &TreeNode<T>) -> Self {
-        Self::new(Rc::downgrade(rc))
+    fn from(arc: &TreeNode<T>) -> Self {
+        Self::new(Arc::downgrade(arc))
     }
 }
 
 impl<T> From<TreeNode<T>> for TreeNodeWeak<T> {
-    fn from(rc: TreeNode<T>) -> Self {
-        Self::new(Rc::downgrade(&rc))
+    fn from(arc: TreeNode<T>) -> Self {
+        Self::new(Arc::downgrade(&arc))
     }
 }

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-macros"
-version = "0.1.0"
+version = "0.1.1"
 license-file = "../LICENSE"
 edition = "2021"
 

--- a/macros/lib.rs
+++ b/macros/lib.rs
@@ -7,15 +7,17 @@
 #[macro_export]
 macro_rules! dd {
     ($expr: expr) => {{
-        println!(
-            "{} = {}::{:?}",
-            stringify!($expr),
-            std::any::type_name_of_val($expr)
-                .replace("core::option::", "")
-                .replace("char", "CodePoint")
-                .replace("resworb_html_parser::", ""),
-            $expr
-        );
+        if cfg!(debug_assertions) {
+            println!(
+                "{} = {}::{:?}",
+                stringify!($expr),
+                std::any::type_name_of_val($expr)
+                    .replace("core::option::", "")
+                    .replace("char", "CodePoint")
+                    .replace("resworb_html_parser::", ""),
+                $expr
+            );
+        }
         $expr
     }};
 }

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-parser"
-version = "0.1.6"
+version = "0.1.7"
 license-file = "../LICENSE"
 edition = "2021"
 

--- a/parser/preprocessor.rs
+++ b/parser/preprocessor.rs
@@ -88,7 +88,7 @@ where
     pub fn next_input(&mut self) -> Option<I> {
         self.next().and_then(|item| {
             let some_item = Some(item);
-            self.current = some_item.clone();
+            self.current = some_item.to_owned();
             some_item
         })
     }
@@ -129,11 +129,11 @@ where
     fn next(&mut self) -> Option<Self::Item> {
         if self.is_replayed {
             self.is_replayed = false;
-            return self.last_consumed_item.clone();
+            return self.last_consumed_item.to_owned();
         };
 
         self.last_consumed_item = self.iter.next();
-        self.last_consumed_item.clone()
+        self.last_consumed_item.to_owned()
     }
 }
 


### PR DESCRIPTION
- feat(html): parser / tree construction
- refactor(html): insertion mode: initial
- feat(html): insertion mode: before html
- feat(html): insertion mode: before head
- docs(html): documentation de code et WebIDL
- feat(macros): dd
- feat(html): insertion mode: in head
- Update rust.yml
- fix: ajout du fichier html de test manquant
- fix: ajoute l'instruction `#[should_panic]` au script de test
- feat(html): insertion mode: "after head"
- feat(html): jeton de caractère NULL #40
- feat(html): jeton de caractère #40
- feat(html): jeton de commentaire #40
- feat(html): jeton doctype #40
- feat(html): jeton de début balise "html" #40
- feat(html): jeton de balise #40
- feat(html): jeton de balise de début "body" #40
- feat(html): jeton balise de début "frameset" #40
- feat(html): jeton EOF #40
- feat(html): jeton de balise de fin "body" #40
- feat(html): jeton de balise de fin "html" #40
- feat(html): jeton de balise #40
- feat(html): jeton de balise de début #40
- feat(html): jeton de balise #40
- feat(html): jeton début de balise "form" #40
- feat(html): jeton début de balise "li" #40
- feat(html): jeton début de balise #40
- feat(html): jeton début de balise "plaintext" #40
- tests(html): insertion mode "initial"
- tests(html): insertion mode "before html"
- refactor(macro): affiche les info. qu'en debug
- feat(html): jeton début de balise "button" #40
- feat(html): jeton balise #40
- feat(html): jeton balise de fin "form" #40
- feat(html): jeton balise de fin "p" #40
- feat(html): jeton balise de fin "li" #40
- feat(html): jeton balise #40
- refactor(html): DOMString et RwLock
- chore(html): code inutile
- feat(html): jeton balise de fin #40
- feat(html): jeton balise #40
- HTML Tree Construction: le mode d'insertion "after body" (#42)
- HTML Tree Construction: le mode d'insertion "after after body" (#44)
- feat(html): jeton balise de début #40
- feat(html): jeton balise de début "nobr" #40
- feat(html): balise de fin #40
- feat(html): jeton balise de début #40
- feat(html): jeton balise de fin #40
- feat(html): jeton balise de début "table" #40
- feat(html): jeton balise #40
- feat(html): jeton balise de début "input" #40
- fix(html): condition manquante pour le tag "input"
- feat(html): jeton balise de début #40
- refactor(html): change le type de self_closing_flag_acknowledge
- refactor(html): passe le jeton par référence aux différentes fonctions
- feat(html): jeton balise de début "hr" #40
- feat(html): jeton balise de début "image" #40
- feat(html): jeton balise de début "textarea" #40
- feat(html): jeton balise de début "xmp" #40
- feat(html): jeton balise de début "iframe" #40
- feat(html): balise de début #40
- feat(html): balise de début "select" #40
- feat(html): balise de début #40
- feat(html): balise de début #40
- feat(html): balise de début #40
- feat(html): balise de début #40
- refactor: `.clone()` -> `.to_owned()`
- refactor: espace de nom
- feat(html): algorithme de l'agence d'adoption
