### PR TITLE
HTML Tree Construction: le mode d'insertion "in template"

### DIFF
--- a/html/elements/Cargo.toml
+++ b/html/elements/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-html-elements"
-version = "0.1.4"
+version = "0.1.5"
 license-file = "../LICENSE"
 edition = "2021"
 

--- a/html/elements/tags/names.rs
+++ b/html/elements/tags/names.rs
@@ -32,6 +32,7 @@ macro_rules! enumerate_html_tag_names {
         impl str::FromStr for tag_names {
             type Err = &'static str;
 
+            #[allow(deprecated)]
             fn from_str(s: &str) -> Result<Self, Self::Err> {
                 Ok(match s {
                     $(| stringify!($name) => Self::$name),*,
@@ -41,6 +42,7 @@ macro_rules! enumerate_html_tag_names {
         }
 
         impl fmt::Display for tag_names {
+            #[allow(deprecated)]
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 write!(f, "{}", match self {
                     $(Self::$name => stringify!($name)),*

--- a/html/parser/Cargo.toml
+++ b/html/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-html-parser"
-version = "0.1.14"
+version = "0.1.15"
 license-file = "../../LICENSE"
 edition = "2021"
 

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -4661,6 +4661,30 @@ where
                     token,
                 );
             }
+
+            // A start tag whose tag name is one of: "td", "th"
+            //
+            // Retirer le mode d'insertion template actuel de la pile des
+            // modes d'insertion des templates.
+            // Ajouter "in row" sur la pile des modes d'insertion de
+            // template de sorte qu'il soit le nouveau mode d'insertion
+            // de template actuel.
+            // Passer le mode d'insertion à "in row", puis retraiter le
+            // jeton.
+            | HTMLToken::Tag(HTMLTagToken {
+                ref name,
+                is_end: false,
+                ..
+            }) if name.is_one_of([tag_names::td, tag_names::th]) => {
+                self.stack_of_template_insertion_modes.pop();
+                self.stack_of_template_insertion_modes
+                    .push(InsertionMode::InRow);
+                self.insertion_mode.switch_to(InsertionMode::InRow);
+                self.process_using_the_rules_for(
+                    self.insertion_mode,
+                    token,
+                );
+            }
             _ => todo!(),
         }
     }

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -4637,6 +4637,30 @@ where
                     token,
                 );
             }
+
+            // A start tag whose tag name is "tr"
+            //
+            // Retirer le mode d'insertion template actuel de la pile des
+            // modes d'insertion des templates.
+            // Ajouter "in table body" sur la pile des modes d'insertion
+            // de template de sorte qu'il soit le nouveau mode
+            // d'insertion de template actuel.
+            // Passer le mode d'insertion à "in table body", puis
+            // retraiter le jeton.
+            | HTMLToken::Tag(HTMLTagToken {
+                ref name,
+                is_end: false,
+                ..
+            }) if tag_names::tr == name => {
+                self.stack_of_template_insertion_modes.pop();
+                self.stack_of_template_insertion_modes
+                    .push(InsertionMode::InTableBody);
+                self.insertion_mode.switch_to(InsertionMode::InTableBody);
+                self.process_using_the_rules_for(
+                    self.insertion_mode,
+                    token,
+                );
+            }
             _ => todo!(),
         }
     }

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -4581,6 +4581,37 @@ where
                 );
             }
 
+            // A start tag whose tag name is one of: "caption", "colgroup",
+            // "tbody", "tfoot", "thead"
+            //
+            // Retirer le mode d'insertion template actuel de la pile des
+            // modes d'insertion des templates.
+            // Ajouter "in table" sur la pile des modes d'insertion de
+            // template de sorte qu'il soit le nouveau mode d'insertion
+            // de template actuel.
+            // Passer le mode d'insertion à "in table", puis retraiter le
+            // jeton.
+            | HTMLToken::Tag(HTMLTagToken {
+                ref name,
+                is_end: false,
+                ..
+            }) if name.is_one_of([
+                tag_names::caption,
+                tag_names::colgroup,
+                tag_names::tbody,
+                tag_names::tfoot,
+                tag_names::thead,
+            ]) =>
+            {
+                self.stack_of_template_insertion_modes.pop();
+                self.stack_of_template_insertion_modes
+                    .push(InsertionMode::InTable);
+                self.insertion_mode.switch_to(InsertionMode::InTable);
+                self.process_using_the_rules_for(
+                    self.insertion_mode,
+                    token,
+                );
+            }
             _ => todo!(),
         }
     }

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -4612,6 +4612,31 @@ where
                     token,
                 );
             }
+
+            // A start tag whose tag name is "col"
+            //
+            // Retirer le mode d'insertion template actuel de la pile des
+            // modes d'insertion des templates.
+            // Ajouter "in column group" sur la pile des modes d'insertion
+            // de template de sorte qu'il soit le nouveau mode
+            // d'insertion de template actuel.
+            // Passer le mode d'insertion à "in column group", puis
+            // retraiter le jeton.
+            | HTMLToken::Tag(HTMLTagToken {
+                ref name,
+                is_end: false,
+                ..
+            }) if tag_names::col == name => {
+                self.stack_of_template_insertion_modes.pop();
+                self.stack_of_template_insertion_modes
+                    .push(InsertionMode::InColumnGroup);
+                self.insertion_mode
+                    .switch_to(InsertionMode::InColumnGroup);
+                self.process_using_the_rules_for(
+                    self.insertion_mode,
+                    token,
+                );
+            }
             _ => todo!(),
         }
     }

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -4685,6 +4685,26 @@ where
                     token,
                 );
             }
+
+            // Any other start tag
+            //
+            // Retirer le mode d'insertion template actuel de la pile des
+            // modes d'insertion des templates.
+            // Ajouter "in body" sur la pile des modes d'insertion de
+            // template de sorte qu'il soit le nouveau mode d'insertion
+            // de template actuel.
+            // Passer le mode d'insertion à "in body", puis retraiter le
+            // jeton.
+            | HTMLToken::Tag(HTMLTagToken { is_end: false, .. }) => {
+                self.stack_of_template_insertion_modes.pop();
+                self.stack_of_template_insertion_modes
+                    .push(InsertionMode::InBody);
+                self.insertion_mode.switch_to(InsertionMode::InBody);
+                self.process_using_the_rules_for(
+                    self.insertion_mode,
+                    token,
+                );
+            }
             _ => todo!(),
         }
     }

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -247,7 +247,9 @@ where
             | InsertionMode::InCell => todo!(),
             | InsertionMode::InSelect => todo!(),
             | InsertionMode::InSelectInTable => todo!(),
-            | InsertionMode::InTemplate => todo!(),
+            | InsertionMode::InTemplate => {
+                self.handle_in_template_insertion_mode(token)
+            }
             | InsertionMode::AfterBody => {
                 self.handle_after_body_insertion_mode(token)
             }
@@ -4528,6 +4530,27 @@ where
             }
 
             | _ => unreachable!(),
+        }
+    }
+
+    fn handle_in_template_insertion_mode(&mut self, token: HTMLToken) {
+        match token {
+            // A character token
+            // A comment token
+            // A DOCTYPE token
+            //
+            // Traiter le jeton selon les règles du mode d'insertion
+            // "in body".
+            | HTMLToken::Character(_)
+            | HTMLToken::Comment(_)
+            | HTMLToken::DOCTYPE(_) => {
+                self.process_using_the_rules_for(
+                    InsertionMode::InBody,
+                    token,
+                );
+            }
+
+            _ => todo!(),
         }
     }
 

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -4550,6 +4550,37 @@ where
                 );
             }
 
+            // A start tag whose tag name is one of: "base", "basefont",
+            // "bgsound", "link", "meta", "noframes", "script", "style",
+            // "template", "title"
+            // An end tag whose tag name is "template"
+            //
+            // Traiter le jeton selon les règles du mode d'insertion
+            // "in head".
+            #[allow(deprecated)]
+            | HTMLToken::Tag(HTMLTagToken {
+                ref name, is_end, ..
+            }) if !is_end
+                && name.is_one_of([
+                    tag_names::base,
+                    tag_names::basefont,
+                    tag_names::bgsound,
+                    tag_names::link,
+                    tag_names::meta,
+                    tag_names::noframes,
+                    tag_names::script,
+                    tag_names::style,
+                    tag_names::template,
+                    tag_names::title,
+                ])
+                || is_end && tag_names::template == name =>
+            {
+                self.process_using_the_rules_for(
+                    InsertionMode::InHead,
+                    token,
+                );
+            }
+
             _ => todo!(),
         }
     }


### PR DESCRIPTION
- feat(html): jeton de caractère #47
- feat(html): jeton de balise #47
- feat(html): jeton balise de début #47
- feat(html): jeton balise de début "col" #47
- feat(html): jeton balise de début "tr" #47
- feat(html): jeton balise de début #47
- feat(html): jeton toutes les balises de début #47
- feat(html): jeton toutes les balises de fin #47
