### PR TITLE
HTML Tree Construction: le mode d'insertion "in table"

### DIFF
--- a/html/parser/Cargo.toml
+++ b/html/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-html-parser"
-version = "0.1.20"
+version = "0.1.21"
 license-file = "../../LICENSE"
 edition = "2021"
 

--- a/html/parser/Cargo.toml
+++ b/html/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-html-parser"
-version = "0.1.25"
+version = "0.1.26"
 license-file = "../../LICENSE"
 edition = "2021"
 

--- a/html/parser/Cargo.toml
+++ b/html/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-html-parser"
-version = "0.1.26"
+version = "0.1.27"
 license-file = "../../LICENSE"
 edition = "2021"
 

--- a/html/parser/Cargo.toml
+++ b/html/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-html-parser"
-version = "0.1.15"
+version = "0.1.16"
 license-file = "../../LICENSE"
 edition = "2021"
 

--- a/html/parser/Cargo.toml
+++ b/html/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-html-parser"
-version = "0.1.23"
+version = "0.1.24"
 license-file = "../../LICENSE"
 edition = "2021"
 

--- a/html/parser/Cargo.toml
+++ b/html/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-html-parser"
-version = "0.1.21"
+version = "0.1.22"
 license-file = "../../LICENSE"
 edition = "2021"
 

--- a/html/parser/Cargo.toml
+++ b/html/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-html-parser"
-version = "0.1.27"
+version = "0.1.28"
 license-file = "../../LICENSE"
 edition = "2021"
 

--- a/html/parser/Cargo.toml
+++ b/html/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-html-parser"
-version = "0.1.24"
+version = "0.1.25"
 license-file = "../../LICENSE"
 edition = "2021"
 

--- a/html/parser/Cargo.toml
+++ b/html/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-html-parser"
-version = "0.1.16"
+version = "0.1.20"
 license-file = "../../LICENSE"
 edition = "2021"
 

--- a/html/parser/Cargo.toml
+++ b/html/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-html-parser"
-version = "0.1.22"
+version = "0.1.23"
 license-file = "../../LICENSE"
 edition = "2021"
 

--- a/html/parser/Cargo.toml
+++ b/html/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-html-parser"
-version = "0.1.28"
+version = "0.1.29"
 license-file = "../../LICENSE"
 edition = "2021"
 

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -4680,6 +4680,30 @@ where
                     token,
                 );
             }
+
+            // A start tag whose tag name is one of: "tbody", "tfoot",
+            // "thead"
+            //
+            // Effacer la pile pour revenir à un contexte de table. (Voir
+            // ci-dessus.)
+            // Insérer un élément HTML pour le jeton, puis passer le mode
+            // d'insertion à "in table body".
+            | HTMLToken::Tag(
+                ref tag_token @ HTMLTagToken {
+                    ref name,
+                    is_end: false,
+                    ..
+                },
+            ) if name.is_one_of([
+                tag_names::tbody,
+                tag_names::tfoot,
+                tag_names::thead,
+            ]) =>
+            {
+                clear_stack_back_to_table_context(self);
+                self.insert_html_element(tag_token);
+                self.insertion_mode.switch_to(InsertionMode::InTableBody);
+            }
             | _ => todo!(),
         }
     }

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -4655,6 +4655,31 @@ where
                 self.insertion_mode
                     .switch_to(InsertionMode::InColumnGroup);
             }
+
+            // A start tag whose tag name is "col"
+            //
+            // Effacer la pile pour revenir à un contexte de table. (Voir
+            // ci-dessus.)
+            // Insérer un élément HTML pour un jeton de balise de début
+            // "colgroup" sans attributs, puis passer le mode d'insertion à
+            // "in column group".
+            // Retraiter le jeton actuel.
+            | HTMLToken::Tag(HTMLTagToken {
+                ref name,
+                is_end: false,
+                ..
+            }) if tag_names::col == name => {
+                clear_stack_back_to_table_context(self);
+                self.insert_html_element(
+                    &HTMLTagToken::start().with_name(tag_names::colgroup),
+                );
+                self.insertion_mode
+                    .switch_to(InsertionMode::InColumnGroup);
+                self.process_using_the_rules_for(
+                    self.insertion_mode,
+                    token,
+                );
+            }
             | _ => todo!(),
         }
     }

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -4933,7 +4933,21 @@ where
                     token,
                 );
             }
-            | _ => todo!(),
+
+            // Anything else
+            //
+            // Erreur d'analyse. Activer le foster_parenting, traiter le
+            // jeton en utilisant les règles du mode d'insertion "in body",
+            // puis désactiver foster_parenting.
+            | _ => {
+                self.parse_error(&token);
+                self.foster_parenting = true;
+                self.process_using_the_rules_for(
+                    InsertionMode::InBody,
+                    token,
+                );
+                self.foster_parenting = false;
+            }
         }
     }
 

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -4733,6 +4733,40 @@ where
                     token,
                 );
             }
+
+            // A start tag whose tag name is "table"
+            //
+            // Erreur d'analyse.
+            // Si la pile d'éléments ouverts ne comporte pas d'élément
+            // table dans la portée de la table, nous devons ignorer le
+            // jeton.
+            // Sinon:
+            // Retirer les éléments de cette pile jusqu'à ce qu'un élément
+            // de table ait été sorti de la pile.
+            // Réinitialiser le mode d'insertion de manière appropriée.
+            // Retraiter le jeton actuel.
+            | HTMLToken::Tag(HTMLTagToken {
+                ref name,
+                is_end: false,
+                ..
+            }) if tag_names::table == name => {
+                self.parse_error(&token);
+
+                if !self.stack_of_open_elements.has_element_in_scope(
+                    tag_names::table,
+                    StackOfOpenElements::table_scope_elements(),
+                ) {
+                    return;
+                }
+
+                self.stack_of_open_elements
+                    .pop_until_tag(tag_names::table);
+                self.reset_insertion_mode_appropriately();
+                self.process_using_the_rules_for(
+                    self.insertion_mode,
+                    token,
+                );
+            }
             | _ => todo!(),
         }
     }

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -4922,6 +4922,17 @@ where
                     |node| element.contains(node),
                 );
             }
+
+            // An end-of-file token
+            //
+            // Traiter le jeton en utilisant les règles du mode d'insertion
+            // "in body".
+            | HTMLToken::EOF => {
+                self.process_using_the_rules_for(
+                    InsertionMode::InBody,
+                    token,
+                );
+            }
             | _ => todo!(),
         }
     }

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -4794,6 +4794,33 @@ where
                     .pop_until_tag(tag_names::table);
                 self.reset_insertion_mode_appropriately();
             }
+
+            // An end tag whose tag name is one of: "body", "caption",
+            // "col", "colgroup", "html", "tbody", "td", "tfoot", "th",
+            // "thead", "tr"
+            //
+            // Erreur d'analyse. Ignorer le jeton.
+            | HTMLToken::Tag(HTMLTagToken {
+                ref name,
+                is_end: true,
+                ..
+            }) if name.is_one_of([
+                tag_names::body,
+                tag_names::caption,
+                tag_names::col,
+                tag_names::colgroup,
+                tag_names::html,
+                tag_names::tbody,
+                tag_names::td,
+                tag_names::tfoot,
+                tag_names::th,
+                tag_names::thead,
+                tag_names::tr,
+            ]) =>
+            {
+                self.parse_error(&token);
+                /* Ignore */
+            }
             | _ => todo!(),
         }
     }

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -4767,6 +4767,33 @@ where
                     token,
                 );
             }
+
+            // An end tag whose tag name is "table"
+            //
+            // Si la pile d'éléments ouverts ne comporte pas d'élément
+            // table dans la portée de la table, il s'agit d'une erreur
+            // d'analyse ; ignorer le jeton.
+            // Sinon:
+            // Retirer les éléments de cette pile jusqu'à ce qu'un élément
+            // de table ait été sorti de la pile.
+            // Réinitialiser le mode d'insertion de manière appropriée.
+            | HTMLToken::Tag(HTMLTagToken {
+                ref name,
+                is_end: true,
+                ..
+            }) if tag_names::table == name => {
+                if !self.stack_of_open_elements.has_element_in_scope(
+                    tag_names::table,
+                    StackOfOpenElements::table_scope_elements(),
+                ) {
+                    self.parse_error(&token);
+                    return;
+                }
+
+                self.stack_of_open_elements
+                    .pop_until_tag(tag_names::table);
+                self.reset_insertion_mode_appropriately();
+            }
             | _ => todo!(),
         }
     }

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -4571,6 +4571,13 @@ where
                     token,
                 );
             }
+
+            // A comment token
+            //
+            // Insérer un commentaire.
+            | HTMLToken::Comment(comment) => {
+                self.insert_comment(comment);
+            }
             | _ => todo!(),
         }
     }

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -4578,6 +4578,14 @@ where
             | HTMLToken::Comment(comment) => {
                 self.insert_comment(comment);
             }
+
+            // A DOCTYPE token
+            //
+            // Erreur d'analyse. Ignorer le jeton.
+            | HTMLToken::DOCTYPE(_) => {
+                self.parse_error(&token);
+                /* Ignore */
+            }
             | _ => todo!(),
         }
     }

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -4821,6 +4821,28 @@ where
                 self.parse_error(&token);
                 /* Ignore */
             }
+
+            // A start tag whose tag name is one of: "style", "script",
+            // "template"
+            // An end tag whose tag name is "template"
+            //
+            // Traiter le jeton en utilisant les règles du mode d'insertion
+            // "in head".
+            | HTMLToken::Tag(HTMLTagToken {
+                ref name, is_end, ..
+            }) if !is_end
+                && name.is_one_of([
+                    tag_names::style,
+                    tag_names::script,
+                    tag_names::template,
+                ])
+                || is_end && tag_names::template == name =>
+            {
+                self.process_using_the_rules_for(
+                    InsertionMode::InHead,
+                    token,
+                );
+            }
             | _ => todo!(),
         }
     }

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -4704,6 +4704,35 @@ where
                 self.insert_html_element(tag_token);
                 self.insertion_mode.switch_to(InsertionMode::InTableBody);
             }
+
+            // A start tag whose tag name is one of: "td", "th", "tr"
+            //
+            // Effacer la pile pour revenir à un contexte de table. (Voir
+            // ci-dessus.)
+            // Insérer un élément HTML pour un jeton de balise de début
+            // "tbody" sans attributs, puis passer le mode d'insertion à
+            // "in table body".
+            // Retraiter le jeton actuel.
+            | HTMLToken::Tag(HTMLTagToken {
+                ref name,
+                is_end: false,
+                ..
+            }) if name.is_one_of([
+                tag_names::td,
+                tag_names::th,
+                tag_names::tr,
+            ]) =>
+            {
+                clear_stack_back_to_table_context(self);
+                self.insert_html_element(
+                    &HTMLTagToken::start().with_name(tag_names::tbody),
+                );
+                self.insertion_mode.switch_to(InsertionMode::InTableBody);
+                self.process_using_the_rules_for(
+                    self.insertion_mode,
+                    token,
+                );
+            }
             | _ => todo!(),
         }
     }

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -4636,6 +4636,25 @@ where
                 self.insert_html_element(tag_token);
                 self.insertion_mode.switch_to(InsertionMode::InCaption);
             }
+
+            // A start tag whose tag name is "colgroup"
+            //
+            // Effacer la pile pour revenir à un contexte de table. (Voir
+            // ci-dessus.)
+            // Insérer un élément HTML pour le jeton, puis passer le mode
+            // d'insertion à "in column group".
+            | HTMLToken::Tag(
+                ref tag_token @ HTMLTagToken {
+                    ref name,
+                    is_end: false,
+                    ..
+                },
+            ) if tag_names::colgroup == name => {
+                clear_stack_back_to_table_context(self);
+                self.insert_html_element(tag_token);
+                self.insertion_mode
+                    .switch_to(InsertionMode::InColumnGroup);
+            }
             | _ => todo!(),
         }
     }

--- a/html/parser/state.rs
+++ b/html/parser/state.rs
@@ -208,6 +208,10 @@ impl StackOfOpenElements {
         Self::scoped_elements_with::<19>([tag_names::button])
     }
 
+    pub(crate) fn table_scope_elements() -> [tag_names; 3] {
+        [tag_names::html, tag_names::table, tag_names::template]
+    }
+
     pub(crate) fn topmost_special_node_below(
         &self,
         formatting_element: &TreeNode<Node>,


### PR DESCRIPTION
- feat(html): jeton de caractère #50
- feat(html): jeton de commentaire #50
- feat(html): jeton doctype #50
- feat(html): jeton balise de début "caption" #50
- feat(html): jeton balise début "colgroup" #50
- feat(html): jeton balise début "col" #50
- feat(html): jeton balise début #50
- feat(html): jeton balise début #50
- feat(html): jeton balise début "table" #50
- feat(html): jeton balise de fin "table" #50
- feat(html): jeton balise de fin #50
- feat(html): jeton balise de début #50
- feat(html): jeton balise de début "input" #50
- feat(html): jeton balise de début "form" #50
- feat(html): jeton EOF #50
- feat(html): jeton anything else #50
