### PR TITLE
HTML Tree Construction: le mode d'insertion "in select"

### DIFF
--- a/html/parser/Cargo.toml
+++ b/html/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-html-parser"
-version = "0.1.61"
+version = "0.1.62"
 license-file = "../../LICENSE"
 edition = "2021"
 

--- a/html/parser/Cargo.toml
+++ b/html/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-html-parser"
-version = "0.1.58"
+version = "0.1.59"
 license-file = "../../LICENSE"
 edition = "2021"
 

--- a/html/parser/Cargo.toml
+++ b/html/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-html-parser"
-version = "0.1.55"
+version = "0.1.56"
 license-file = "../../LICENSE"
 edition = "2021"
 

--- a/html/parser/Cargo.toml
+++ b/html/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-html-parser"
-version = "0.1.60"
+version = "0.1.61"
 license-file = "../../LICENSE"
 edition = "2021"
 

--- a/html/parser/Cargo.toml
+++ b/html/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-html-parser"
-version = "0.1.54"
+version = "0.1.55"
 license-file = "../../LICENSE"
 edition = "2021"
 

--- a/html/parser/Cargo.toml
+++ b/html/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-html-parser"
-version = "0.1.63"
+version = "0.1.64"
 license-file = "../../LICENSE"
 edition = "2021"
 

--- a/html/parser/Cargo.toml
+++ b/html/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-html-parser"
-version = "0.1.50"
+version = "0.1.51"
 license-file = "../../LICENSE"
 edition = "2021"
 

--- a/html/parser/Cargo.toml
+++ b/html/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-html-parser"
-version = "0.1.56"
+version = "0.1.57"
 license-file = "../../LICENSE"
 edition = "2021"
 

--- a/html/parser/Cargo.toml
+++ b/html/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-html-parser"
-version = "0.1.52"
+version = "0.1.53"
 license-file = "../../LICENSE"
 edition = "2021"
 

--- a/html/parser/Cargo.toml
+++ b/html/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-html-parser"
-version = "0.1.62"
+version = "0.1.63"
 license-file = "../../LICENSE"
 edition = "2021"
 

--- a/html/parser/Cargo.toml
+++ b/html/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-html-parser"
-version = "0.1.57"
+version = "0.1.58"
 license-file = "../../LICENSE"
 edition = "2021"
 

--- a/html/parser/Cargo.toml
+++ b/html/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-html-parser"
-version = "0.1.51"
+version = "0.1.52"
 license-file = "../../LICENSE"
 edition = "2021"
 

--- a/html/parser/Cargo.toml
+++ b/html/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-html-parser"
-version = "0.1.59"
+version = "0.1.60"
 license-file = "../../LICENSE"
 edition = "2021"
 

--- a/html/parser/Cargo.toml
+++ b/html/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-html-parser"
-version = "0.1.53"
+version = "0.1.54"
 license-file = "../../LICENSE"
 edition = "2021"
 

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -5856,6 +5856,27 @@ where
                 }
             }
 
+            // An end tag whose tag name is "option"
+            //
+            // Si le noeud actuel est un élément option, alors il faut
+            // sortir ce noeud de la pile des éléments ouverts. Sinon, il
+            // s'agit d'une erreur d'analyse ; ignorez le jeton.
+            | HTMLToken::Tag(HTMLTagToken {
+                ref name,
+                is_end: true,
+                ..
+            }) if tag_names::option == name => {
+                if let Some(cnode) = self.current_node() {
+                    if cnode.element_ref().tag_name() == tag_names::option
+                    {
+                        self.stack_of_open_elements.pop();
+                    } else {
+                        self.parse_error(&token);
+                        /* Ignore */
+                    }
+                }
+            }
+
             | _ => todo!(),
         }
     }

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -5739,6 +5739,21 @@ where
                 self.parse_error(&token);
                 /* Ignore */
             }
+
+            // A start tag whose tag name is "html"
+            //
+            // Traiter le jeton en utilisant les règles du mode d'insertion
+            // "in body".
+            | HTMLToken::Tag(HTMLTagToken {
+                ref name,
+                is_end: false,
+                ..
+            }) if tag_names::html == name => {
+                self.process_using_the_rules_for(
+                    InsertionMode::InBody,
+                    token,
+                );
+            }
             | _ => todo!(),
         }
     }

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -5717,6 +5717,13 @@ where
                 self.parse_error(&token);
                 /* Ignore */
             }
+
+            // Any other character token
+            //
+            // Insérez le caractère du jeton.
+            | HTMLToken::Character(ch) => {
+                self.insert_character(ch);
+            }
             | _ => todo!(),
         }
     }

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -5777,6 +5777,38 @@ where
                 self.insert_html_element(tag_token);
             }
 
+            // A start tag whose tag name is "optgroup"
+            //
+            // Si le noeud actuel est un élément option, il faut retirer
+            // ce noeud de la pile des éléments ouverts.
+            // Si le noeud actuel est un élément optgroup, il faut
+            // retirer ce noeud de la pile des éléments ouverts.
+            // Insérer un élément HTML pour le jeton.
+            | HTMLToken::Tag(
+                ref tag_token @ HTMLTagToken {
+                    ref name,
+                    is_end: false,
+                    ..
+                },
+            ) if tag_names::optgroup == name => {
+                if let Some(cnode) = self.current_node() {
+                    if cnode.element_ref().tag_name() == tag_names::option
+                    {
+                        self.stack_of_open_elements.pop();
+                    }
+                }
+
+                if let Some(cnode) = self.current_node() {
+                    if cnode.element_ref().tag_name()
+                        == tag_names::optgroup
+                    {
+                        self.stack_of_open_elements.pop();
+                    }
+                }
+
+                self.insert_html_element(tag_token);
+            }
+
             | _ => todo!(),
         }
     }

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -5731,6 +5731,14 @@ where
             | HTMLToken::Comment(comment) => {
                 self.insert_comment(comment);
             }
+
+            // A DOCTYPE token
+            //
+            // Erreur d'analyse. Ignorer le jeton.
+            | HTMLToken::DOCTYPE(_) => {
+                self.parse_error(&token);
+                /* Ignore */
+            }
             | _ => todo!(),
         }
     }

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -5954,6 +5954,26 @@ where
                 );
             }
 
+            // A start tag whose tag name is one of: "script", "template"
+            // An end tag whose tag name is "template"
+            //
+            // Traiter le jeton en utilisant les règles du mode d'insertion
+            // "in head".
+            | HTMLToken::Tag(HTMLTagToken {
+                ref name, is_end, ..
+            }) if !is_end
+                && name.is_one_of([
+                    tag_names::script,
+                    tag_names::template,
+                ])
+                || is_end && tag_names::template == name =>
+            {
+                self.process_using_the_rules_for(
+                    InsertionMode::InHead,
+                    token,
+                );
+            }
+
             | _ => todo!(),
         }
     }

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -5754,6 +5754,29 @@ where
                     token,
                 );
             }
+
+            // A start tag whose tag name is "option"
+            //
+            // Si le noeud actuel est un élément d'option, il faut retirer
+            // ce noeud de la pile des éléments ouverts.
+            // Insérer un élément HTML pour le jeton.
+            | HTMLToken::Tag(
+                ref tag_token @ HTMLTagToken {
+                    ref name,
+                    is_end: false,
+                    ..
+                },
+            ) if tag_names::option == name => {
+                if let Some(cnode) = self.current_node() {
+                    if cnode.element_ref().tag_name() == tag_names::option
+                    {
+                        self.stack_of_open_elements.pop();
+                    }
+                }
+
+                self.insert_html_element(tag_token);
+            }
+
             | _ => todo!(),
         }
     }

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -5724,6 +5724,13 @@ where
             | HTMLToken::Character(ch) => {
                 self.insert_character(ch);
             }
+
+            // A comment token
+            //
+            // Insérez un commentaire.
+            | HTMLToken::Comment(comment) => {
+                self.insert_comment(comment);
+            }
             | _ => todo!(),
         }
     }

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -5985,7 +5985,13 @@ where
                 );
             }
 
-            | _ => todo!(),
+            // Anything else
+            //
+            // Erreur d'analyse. Ignorer le jeton.
+            | _ => {
+                self.parse_error(&token);
+                /* Ignore */
+            }
         }
     }
 

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -5974,6 +5974,17 @@ where
                 );
             }
 
+            // An end-of-file token
+            //
+            // Traite rle jeton en utilisant les règles du mode d'insertion
+            // "in body".
+            | HTMLToken::EOF => {
+                self.process_using_the_rules_for(
+                    InsertionMode::InBody,
+                    token,
+                );
+            }
+
             | _ => todo!(),
         }
     }

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -261,7 +261,9 @@ where
             | InsertionMode::InCell => {
                 self.handle_in_cell_insertion_mode(token);
             }
-            | InsertionMode::InSelect => todo!(),
+            | InsertionMode::InSelect => {
+                self.handle_in_select_insertion_mode(token);
+            }
             | InsertionMode::InSelectInTable => todo!(),
             | InsertionMode::InTemplate => {
                 self.handle_in_template_insertion_mode(token)
@@ -5703,6 +5705,19 @@ where
                     token,
                 );
             }
+        }
+    }
+
+    fn handle_in_select_insertion_mode(&mut self, token: HTMLToken) {
+        match token {
+            // A character token that is U+0000 NULL
+            //
+            // Erreur d'analyse. Ignorer le jeton.
+            | HTMLToken::Character('\0') => {
+                self.parse_error(&token);
+                /* Ignore */
+            }
+            | _ => todo!(),
         }
     }
 

--- a/html/parser/state.rs
+++ b/html/parser/state.rs
@@ -163,6 +163,29 @@ impl StackOfOpenElements {
         })
     }
 
+    pub(crate) fn has_element_in_scope_except<const N: usize>(
+        &self,
+        tag_name: tag_names,
+        list: [tag_names; N],
+    ) -> bool {
+        self.has_elements_in_scope_except([tag_name], list)
+    }
+
+    pub(crate) fn has_elements_in_scope_except<const N: usize>(
+        &self,
+        tag_names_list: impl IntoIterator<Item = tag_names> + Copy,
+        except_list: [tag_names; N],
+    ) -> bool {
+        self.elements.iter().rev().any(|node| {
+            let element = node.element_ref();
+            let name = element.local_name();
+            tag_names_list.into_iter().any(|tag_name| tag_name == name)
+                || !except_list
+                    .into_iter()
+                    .any(|tag_name| tag_name != name)
+        })
+    }
+
     pub(crate) fn has_element_with_tag_name(
         &self,
         tag_name: tag_names,
@@ -224,6 +247,10 @@ impl StackOfOpenElements {
 
     pub(crate) fn button_scope_elements() -> [tag_names; 19] {
         Self::scoped_elements_with::<19>([tag_names::button])
+    }
+
+    pub(crate) fn select_scope_elements() -> [tag_names; 2] {
+        [tag_names::optgroup, tag_names::option]
     }
 
     pub(crate) fn table_scope_elements() -> [tag_names; 3] {


### PR DESCRIPTION
- feat(html): jeton de caractère NULL #60
- feat(html): jeton de caractère #60
- feat(html): jeton de commentaire #60
- feat(html): jeton doctype #60
- feat(html): jeton balise de début "html" #60
- feat(html): jeton balise de début "option" #60
- feat(html): jeton balise de début "optgroup" #60
- feat(html): jeton balise de fin "optgroup" #60
- feat(html): jeton balise de fin "option" #60
- feat(html): jeton balise de fin "select" #60
- feat(html): jeton balise de début #60
- feat(html): jeton balise #60
- feat(html): jeton EOF #60
- feat(html): jeton anything else #60
