### PR TITLE
HTML Tree Construction: le mode d'insertion "in frameset"

### DIFF
--- a/html/parser/Cargo.toml
+++ b/html/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-html-parser"
-version = "0.1.87"
+version = "0.1.88"
 license-file = "../../LICENSE"
 edition = "2021"
 

--- a/html/parser/Cargo.toml
+++ b/html/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-html-parser"
-version = "0.1.86"
+version = "0.1.87"
 license-file = "../../LICENSE"
 edition = "2021"
 

--- a/html/parser/Cargo.toml
+++ b/html/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-html-parser"
-version = "0.1.89"
+version = "0.1.90"
 license-file = "../../LICENSE"
 edition = "2021"
 

--- a/html/parser/Cargo.toml
+++ b/html/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-html-parser"
-version = "0.1.90"
+version = "0.1.91"
 license-file = "../../LICENSE"
 edition = "2021"
 

--- a/html/parser/Cargo.toml
+++ b/html/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-html-parser"
-version = "0.1.92"
+version = "0.1.93"
 license-file = "../../LICENSE"
 edition = "2021"
 

--- a/html/parser/Cargo.toml
+++ b/html/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-html-parser"
-version = "0.1.88"
+version = "0.1.89"
 license-file = "../../LICENSE"
 edition = "2021"
 

--- a/html/parser/Cargo.toml
+++ b/html/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-html-parser"
-version = "0.1.94"
+version = "0.1.95"
 license-file = "../../LICENSE"
 edition = "2021"
 

--- a/html/parser/Cargo.toml
+++ b/html/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-html-parser"
-version = "0.1.93"
+version = "0.1.94"
 license-file = "../../LICENSE"
 edition = "2021"
 

--- a/html/parser/Cargo.toml
+++ b/html/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-html-parser"
-version = "0.1.91"
+version = "0.1.92"
 license-file = "../../LICENSE"
 edition = "2021"
 

--- a/html/parser/Cargo.toml
+++ b/html/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-html-parser"
-version = "0.1.85"
+version = "0.1.86"
 license-file = "../../LICENSE"
 edition = "2021"
 

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -6896,6 +6896,24 @@ where
                 );
             }
 
+            // An end-of-file token
+            //
+            // Si le nœud actuel n'est pas l'élément html racine, il s'agit
+            // d'une erreur d'analyse.
+            // Note: Le nœud actuel ne peut être que l'élément html racine
+            // dans le cas d'un fragment.
+            // Arrêter l'analyse.
+            | HTMLToken::EOF => {
+                if let Some(cnode) = self.current_node() {
+                    if cnode.element_ref().tag_name() != tag_names::html {
+                        self.parse_error(&token);
+                        return;
+                    }
+                }
+
+                self.stop_parsing = true;
+            }
+
             // Anything else
             //
             // Erreur d'analyse. Ignorer le jeton.

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -6786,6 +6786,13 @@ where
                 self.insert_character(ch);
             }
 
+            // A comment token
+            //
+            // Insérer un commentaire.
+            | HTMLToken::Comment(comment) => {
+                self.insert_comment(comment);
+            }
+
             // Anything else
             //
             // Erreur d'analyse. Ignorer le jeton.

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -279,7 +279,9 @@ where
             | InsertionMode::AfterBody => {
                 self.handle_after_body_insertion_mode(token);
             }
-            | InsertionMode::InFrameset => todo!(),
+            | InsertionMode::InFrameset => {
+                self.handle_in_frameset_insertion_mode(token);
+            }
             | InsertionMode::AfterFrameset => todo!(),
             | InsertionMode::AfterAfterBody => {
                 self.handle_after_after_body_insertion_mode(token);
@@ -6767,6 +6769,18 @@ where
                     self.insertion_mode,
                     token,
                 );
+            }
+        }
+    }
+
+    fn handle_in_frameset_insertion_mode(&mut self, token: HTMLToken) {
+        match token {
+            // Anything else
+            //
+            // Erreur d'analyse. Ignorer le jeton.
+            | _ => {
+                self.parse_error(&token);
+                /* Ignore */
             }
         }
     }

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -6793,6 +6793,14 @@ where
                 self.insert_comment(comment);
             }
 
+            // A DOCTYPE token
+            //
+            // Erreur d'analyse. Ignorer le jeton.
+            | HTMLToken::DOCTYPE(_) => {
+                self.parse_error(&token);
+                /* Ignore */
+            }
+
             // Anything else
             //
             // Erreur d'analyse. Ignorer le jeton.

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -6816,6 +6816,20 @@ where
                 );
             }
 
+            // A start tag whose tag name is "frameset"
+            //
+            // Insérer un élément HTML pour le jeton.
+            #[allow(deprecated)]
+            | HTMLToken::Tag(
+                ref tag_token @ HTMLTagToken {
+                    ref name,
+                    is_end: false,
+                    ..
+                },
+            ) if tag_names::frameset == name => {
+                self.insert_html_element(tag_token);
+            }
+
             // Anything else
             //
             // Erreur d'analyse. Ignorer le jeton.

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -6775,6 +6775,17 @@ where
 
     fn handle_in_frameset_insertion_mode(&mut self, token: HTMLToken) {
         match token {
+            // U+0009 CHARACTER TABULATION
+            // U+000A LINE FEED (LF)
+            // U+000C FORM FEED (FF)
+            // U+000D CARRIAGE RETURN (CR)
+            // U+0020 SPACE
+            //
+            // Insérer le caractère.
+            | HTMLToken::Character(ch) if ch.is_ascii_whitespace() => {
+                self.insert_character(ch);
+            }
+
             // Anything else
             //
             // Erreur d'analyse. Ignorer le jeton.

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -6880,6 +6880,22 @@ where
                 token.as_tag_mut().set_acknowledge_self_closing_flag();
             }
 
+            // A start tag whose tag name is "noframes"
+            //
+            // Traiter le jeton en utilisant les règles du mode d'insertion
+            // "in head".
+            #[allow(deprecated)] // noframes
+            | HTMLToken::Tag(HTMLTagToken {
+                ref name,
+                is_end: false,
+                ..
+            }) if tag_names::noframes == name => {
+                self.process_using_the_rules_for(
+                    InsertionMode::InHead,
+                    token,
+                );
+            }
+
             // Anything else
             //
             // Erreur d'analyse. Ignorer le jeton.

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -6773,7 +6773,7 @@ where
         }
     }
 
-    fn handle_in_frameset_insertion_mode(&mut self, token: HTMLToken) {
+    fn handle_in_frameset_insertion_mode(&mut self, mut token: HTMLToken) {
         match token {
             // U+0009 CHARACTER TABULATION
             // U+000A LINE FEED (LF)
@@ -6859,6 +6859,25 @@ where
                     self.insertion_mode
                         .switch_to(InsertionMode::AfterFrameset);
                 }
+            }
+
+            // A start tag whose tag name is "frame"
+            //
+            // Insérer un élément HTML pour le jeton. Extraire
+            // immédiatement le nœud de la pile d'éléments ouverts.
+            // Accuser réception du drapeau de fermeture automatique du
+            // jeton, si défini.
+            #[allow(deprecated)] // frame
+            | HTMLToken::Tag(
+                ref tag_token @ HTMLTagToken {
+                    ref name,
+                    is_end: false,
+                    ..
+                },
+            ) if tag_names::frame == name => {
+                self.insert_html_element(tag_token);
+                self.stack_of_open_elements.pop();
+                token.as_tag_mut().set_acknowledge_self_closing_flag();
             }
 
             // Anything else

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -6801,6 +6801,21 @@ where
                 /* Ignore */
             }
 
+            // A start tag whose tag name is "html"
+            //
+            // Traiter le jeton en utilisant les règles du mode d'insertion
+            // "in body".
+            | HTMLToken::Tag(HTMLTagToken {
+                ref name,
+                is_end: false,
+                ..
+            }) if tag_names::html == name => {
+                self.process_using_the_rules_for(
+                    InsertionMode::InBody,
+                    token,
+                );
+            }
+
             // Anything else
             //
             // Erreur d'analyse. Ignorer le jeton.


### PR DESCRIPTION
- feat(html): jeton anything else #69
- feat(html): jeton caractère #69
- feat(html): jeton commentaire #69
- feat(html): jeton DOCTYPE #69
- feat(html): jeton balise de début "html" #69
- feat(html): jeton balise de début "frameset" #69
- feat(html): jeton balise de fin "frameset" #69
- feat(html): jeton balise de début "frame" #69
- feat(html): jeton balise de début "noframes" #69
- feat(html): jeton EOF #69
