### PR TITLE
HTML Tree Construction: le mode d'insertion "after frameset"

### DIFF
--- a/html/parser/Cargo.toml
+++ b/html/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-html-parser"
-version = "0.1.97"
+version = "0.1.98"
 license-file = "../../LICENSE"
 edition = "2021"
 

--- a/html/parser/Cargo.toml
+++ b/html/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-html-parser"
-version = "0.1.101"
+version = "0.1.102"
 license-file = "../../LICENSE"
 edition = "2021"
 

--- a/html/parser/Cargo.toml
+++ b/html/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-html-parser"
-version = "0.1.99"
+version = "0.1.100"
 license-file = "../../LICENSE"
 edition = "2021"
 

--- a/html/parser/Cargo.toml
+++ b/html/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-html-parser"
-version = "0.1.98"
+version = "0.1.99"
 license-file = "../../LICENSE"
 edition = "2021"
 

--- a/html/parser/Cargo.toml
+++ b/html/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-html-parser"
-version = "0.1.95"
+version = "0.1.96"
 license-file = "../../LICENSE"
 edition = "2021"
 

--- a/html/parser/Cargo.toml
+++ b/html/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-html-parser"
-version = "0.1.100"
+version = "0.1.101"
 license-file = "../../LICENSE"
 edition = "2021"
 

--- a/html/parser/Cargo.toml
+++ b/html/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-html-parser"
-version = "0.1.96"
+version = "0.1.97"
 license-file = "../../LICENSE"
 edition = "2021"
 

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -6982,6 +6982,13 @@ where
                     .switch_to(InsertionMode::AfterAfterFrameset);
             }
 
+            // An end-of-file token
+            //
+            // Arrêter l'analyse.
+            | HTMLToken::EOF => {
+                self.stop_parsing = true;
+            }
+
             // Anything else
             //
             // Erreur d'analyse. Ignorer le jeton.

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -6955,6 +6955,21 @@ where
                 /* Ignore */
             }
 
+            // A start tag whose tag name is "html"
+            //
+            // Traiter le jeton en utilisant les règles du mode d'insertion
+            // "in body".
+            | HTMLToken::Tag(HTMLTagToken {
+                ref name,
+                is_end: false,
+                ..
+            }) if tag_names::html == name => {
+                self.process_using_the_rules_for(
+                    InsertionMode::InBody,
+                    token,
+                );
+            }
+
             // Anything else
             //
             // Erreur d'analyse. Ignorer le jeton.

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -6947,6 +6947,14 @@ where
                 self.insert_comment(comment);
             }
 
+            // A DOCTYPE token
+            //
+            // Erreur d'analyse. Ignorer le jeton.
+            | HTMLToken::DOCTYPE(_) => {
+                self.parse_error(&token);
+                /* Ignore */
+            }
+
             // Anything else
             //
             // Erreur d'analyse. Ignorer le jeton.

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -6970,6 +6970,18 @@ where
                 );
             }
 
+            // An end tag whose tag name is "html"
+            //
+            // Passer le mode d'insertion à "after after frameset".
+            | HTMLToken::Tag(HTMLTagToken {
+                ref name,
+                is_end: true,
+                ..
+            }) if tag_names::html == name => {
+                self.insertion_mode
+                    .switch_to(InsertionMode::AfterAfterFrameset);
+            }
+
             // Anything else
             //
             // Erreur d'analyse. Ignorer le jeton.

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -6940,6 +6940,13 @@ where
                 self.insert_character(ch);
             }
 
+            // A comment token
+            //
+            // Insérer un commentaire.
+            | HTMLToken::Comment(comment) => {
+                self.insert_comment(comment);
+            }
+
             // Anything else
             //
             // Erreur d'analyse. Ignorer le jeton.

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -282,7 +282,9 @@ where
             | InsertionMode::InFrameset => {
                 self.handle_in_frameset_insertion_mode(token);
             }
-            | InsertionMode::AfterFrameset => todo!(),
+            | InsertionMode::AfterFrameset => {
+                self.handle_after_frameset_insertion_mode(token);
+            }
             | InsertionMode::AfterAfterBody => {
                 self.handle_after_after_body_insertion_mode(token);
             }
@@ -6914,6 +6916,18 @@ where
                 self.stop_parsing = true;
             }
 
+            // Anything else
+            //
+            // Erreur d'analyse. Ignorer le jeton.
+            | _ => {
+                self.parse_error(&token);
+                /* Ignore */
+            }
+        }
+    }
+
+    fn handle_after_frameset_insertion_mode(&mut self, token: HTMLToken) {
+        match token {
             // Anything else
             //
             // Erreur d'analyse. Ignorer le jeton.

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -6928,6 +6928,18 @@ where
 
     fn handle_after_frameset_insertion_mode(&mut self, token: HTMLToken) {
         match token {
+            // U+0009 CHARACTER TABULATION
+            // U+000A LINE FEED (LF)
+            // U+000C
+            // FORM FEED (FF)
+            // U+000D CARRIAGE RETURN (CR)
+            // U+0020 SPACE
+            //
+            // Insérer le caractère.
+            | HTMLToken::Character(ch) if ch.is_ascii_whitespace() => {
+                self.insert_character(ch);
+            }
+
             // Anything else
             //
             // Erreur d'analyse. Ignorer le jeton.


### PR DESCRIPTION
- feat(html): jeton anything else #71
- feat(html): jeton de caractère #71
- feat(html): jeton commentaire #71
- feat(html): jeton DOCTYPE #71
- feat(html): jeton balise de début "html" #71
- feat(html): jeton balise de fin "html" #71
- feat(html): jeton EOF #71
