### PR TITLE
HTML Tree Construction: le mode d'insertion "after after frameset"

### DIFF
--- a/html/parser/Cargo.toml
+++ b/html/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-html-parser"
-version = "0.1.102"
+version = "0.1.103"
 license-file = "../../LICENSE"
 edition = "2021"
 

--- a/html/parser/Cargo.toml
+++ b/html/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-html-parser"
-version = "0.1.106"
+version = "0.1.107"
 license-file = "../../LICENSE"
 edition = "2021"
 

--- a/html/parser/Cargo.toml
+++ b/html/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-html-parser"
-version = "0.1.104"
+version = "0.1.105"
 license-file = "../../LICENSE"
 edition = "2021"
 

--- a/html/parser/Cargo.toml
+++ b/html/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-html-parser"
-version = "0.1.105"
+version = "0.1.106"
 license-file = "../../LICENSE"
 edition = "2021"
 

--- a/html/parser/Cargo.toml
+++ b/html/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-html-parser"
-version = "0.1.103"
+version = "0.1.104"
 license-file = "../../LICENSE"
 edition = "2021"
 

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -7124,6 +7124,22 @@ where
                 self.stop_parsing = true;
             }
 
+            // A start tag whose tag name is "noframes"
+            //
+            // Traiter le jeton en utilisant les règles du mode d'insertion
+            // "in head".
+            #[allow(deprecated)]
+            | HTMLToken::Tag(HTMLTagToken {
+                ref name,
+                is_end: false,
+                ..
+            }) if tag_names::noframes == name => {
+                self.process_using_the_rules_for(
+                    InsertionMode::InHead,
+                    token,
+                );
+            }
+
             // Anything else
             //
             // Erreur d'analyse. Ignorer le jeton.

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -7075,6 +7075,15 @@ where
         token: HTMLToken,
     ) {
         match token {
+            // A comment token
+            //
+            // Insérer un commentaire comme dernier enfant de l'objet
+            // [Document].
+            | HTMLToken::Comment(comment) => {
+                let comment = CommentNode::new(&self.document, comment);
+                self.document.append_child(comment.to_owned());
+            }
+
             // Anything else
             //
             // Erreur d'analyse. Ignorer le jeton.

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -7084,6 +7084,39 @@ where
                 self.document.append_child(comment.to_owned());
             }
 
+            // A DOCTYPE token
+            // U+0009 CHARACTER TABULATION
+            // U+000A LINE FEED (LF)
+            // U+000C FORM FEED (FF)
+            // U+000D CARRIAGE RETURN (CR)
+            // U+0020 SPACE
+            // A start tag whose tag name is "html"
+            //
+            // Traiter le jeton en utilisant les règles du mode d'insertion
+            // "in body".
+            | HTMLToken::DOCTYPE(_) => {
+                self.process_using_the_rules_for(
+                    InsertionMode::InBody,
+                    token,
+                );
+            }
+            | HTMLToken::Character(ch) if ch.is_ascii_whitespace() => {
+                self.process_using_the_rules_for(
+                    InsertionMode::InBody,
+                    token,
+                );
+            }
+            | HTMLToken::Tag(HTMLTagToken {
+                ref name,
+                is_end: false,
+                ..
+            }) if tag_names::html == name => {
+                self.process_using_the_rules_for(
+                    InsertionMode::InBody,
+                    token,
+                );
+            }
+
             // Anything else
             //
             // Erreur d'analyse. Ignorer le jeton.

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -7117,6 +7117,13 @@ where
                 );
             }
 
+            // An end-of-file token
+            //
+            // Arrêter l'analyse.
+            | HTMLToken::EOF => {
+                self.stop_parsing = true;
+            }
+
             // Anything else
             //
             // Erreur d'analyse. Ignorer le jeton.

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -288,7 +288,9 @@ where
             | InsertionMode::AfterAfterBody => {
                 self.handle_after_after_body_insertion_mode(token);
             }
-            | InsertionMode::AfterAfterFrameset => todo!(),
+            | InsertionMode::AfterAfterFrameset => {
+                self.handle_after_after_frameset_insertion_mode(token);
+            }
         }
     }
 
@@ -7064,6 +7066,21 @@ where
                     self.insertion_mode,
                     token,
                 );
+            }
+        }
+    }
+
+    fn handle_after_after_frameset_insertion_mode(
+        &mut self,
+        token: HTMLToken,
+    ) {
+        match token {
+            // Anything else
+            //
+            // Erreur d'analyse. Ignorer le jeton.
+            | _ => {
+                self.parse_error(&token);
+                /* Ignore */
             }
         }
     }


### PR DESCRIPTION
- feat(html): jeton anything else #73
- feat(html): jeton commentaire #73
- feat(html): jeton doctype, caractère et balise de début "html" #73
- feat(html): jeton EOF #73
- feat(html): jeton balise de début "noframes" #73
