### PR TITLE
CSS Tokenization

### DIFF
--- a/css/parser/Cargo.toml
+++ b/css/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-css-parser"
-version = "0.1.16"
+version = "0.1.17"
 license-file = "../LICENSE"
 edition = "2021"
 

--- a/css/parser/Cargo.toml
+++ b/css/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-css-parser"
-version = "0.1.14"
+version = "0.1.15"
 license-file = "../LICENSE"
 edition = "2021"
 

--- a/css/parser/Cargo.toml
+++ b/css/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-css-parser"
-version = "0.1.3"
+version = "0.1.4"
 license-file = "../LICENSE"
 edition = "2021"
 

--- a/css/parser/Cargo.toml
+++ b/css/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-css-parser"
-version = "0.1.2"
+version = "0.1.3"
 license-file = "../LICENSE"
 edition = "2021"
 

--- a/css/parser/Cargo.toml
+++ b/css/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-css-parser"
-version = "0.1.5"
+version = "0.1.6"
 license-file = "../LICENSE"
 edition = "2021"
 

--- a/css/parser/Cargo.toml
+++ b/css/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-css-parser"
-version = "0.1.15"
+version = "0.1.16"
 license-file = "../LICENSE"
 edition = "2021"
 

--- a/css/parser/Cargo.toml
+++ b/css/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-css-parser"
-version = "0.1.0"
+version = "0.1.1"
 license-file = "../LICENSE"
 edition = "2021"
 

--- a/css/parser/Cargo.toml
+++ b/css/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-css-parser"
-version = "0.1.11"
+version = "0.1.12"
 license-file = "../LICENSE"
 edition = "2021"
 

--- a/css/parser/Cargo.toml
+++ b/css/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-css-parser"
-version = "0.1.13"
+version = "0.1.14"
 license-file = "../LICENSE"
 edition = "2021"
 

--- a/css/parser/Cargo.toml
+++ b/css/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-css-parser"
-version = "0.1.1"
+version = "0.1.2"
 license-file = "../LICENSE"
 edition = "2021"
 

--- a/css/parser/Cargo.toml
+++ b/css/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-css-parser"
-version = "0.1.6"
+version = "0.1.7"
 license-file = "../LICENSE"
 edition = "2021"
 

--- a/css/parser/Cargo.toml
+++ b/css/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-css-parser"
-version = "0.1.7"
+version = "0.1.11"
 license-file = "../LICENSE"
 edition = "2021"
 

--- a/css/parser/Cargo.toml
+++ b/css/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-css-parser"
-version = "0.1.4"
+version = "0.1.5"
 license-file = "../LICENSE"
 edition = "2021"
 

--- a/css/parser/Cargo.toml
+++ b/css/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-css-parser"
-version = "0.1.12"
+version = "0.1.13"
 license-file = "../LICENSE"
 edition = "2021"
 

--- a/css/parser/codepoint.rs
+++ b/css/parser/codepoint.rs
@@ -49,10 +49,22 @@ pub trait CSSCodePoint: Copy {
 
     /// Saut de ligne.
     ///
-    /// Note: U+000D CARRIAGE RETURN et U+000C FORM FEED ne sont pas inclus
-    /// dans cette définition, car ils sont convertis en U+000A LINE FEED
-    /// lors du prétraitement.
+    /// NOTE(css): U+000D CARRIAGE RETURN et U+000C FORM FEED ne sont pas
+    /// inclus dans cette définition, car ils sont convertis en U+000A LINE
+    /// FEED lors du prétraitement.
     fn is_newline(self) -> bool;
+
+    /// non-ASCII code point
+    ///
+    /// Un point de code dont la valeur est égale ou supérieure à U+0080
+    /// <control>
+    fn is_non_ascii_codepoint(self) -> bool;
+
+    /// maximum allowed code point
+    ///
+    /// Le plus grand point de code défini par Unicode : U+10FFFF.
+    fn is_gt_maximum_allowed_codepoint(self) -> bool;
+    fn is_lt_maximum_allowed_codepoint(self) -> bool;
 }
 
 // -------------- //
@@ -75,7 +87,7 @@ impl CSSCodePoint for CodePoint {
     }
 
     fn is_ident_start_codepoint(self) -> bool {
-        self.is_letter()
+        self.is_letter() || self.is_non_ascii_codepoint() || self == '_'
     }
 
     fn is_letter(self) -> bool {
@@ -92,5 +104,17 @@ impl CSSCodePoint for CodePoint {
 
     fn is_newline(self) -> bool {
         self == '\n'
+    }
+
+    fn is_non_ascii_codepoint(self) -> bool {
+        self as u32 >= 0x80
+    }
+
+    fn is_gt_maximum_allowed_codepoint(self) -> bool {
+        self > '\u{10FFFF}'
+    }
+
+    fn is_lt_maximum_allowed_codepoint(self) -> bool {
+        self < '\u{10FFFF}'
     }
 }

--- a/css/parser/codepoint.rs
+++ b/css/parser/codepoint.rs
@@ -60,6 +60,13 @@ pub trait CSSCodePoint: Copy {
     /// <control>
     fn is_non_ascii_codepoint(self) -> bool;
 
+    /// non-printable code point
+    ///
+    /// Un point de code entre U+0000 NULL et U+0008 BACKSPACE inclus, ou
+    /// U+000B LINE TABULATION, ou un point de code entre U+000E SHIFT OUT
+    /// et U+001F INFORMATION SEPARATOR ONE inclus, ou U+007F DELETE.
+    fn is_non_printable_codepoint(self) -> bool;
+
     /// maximum allowed code point
     ///
     /// Le plus grand point de code défini par Unicode : U+10FFFF.
@@ -108,6 +115,10 @@ impl CSSCodePoint for CodePoint {
 
     fn is_non_ascii_codepoint(self) -> bool {
         self as u32 >= 0x80
+    }
+
+    fn is_non_printable_codepoint(self) -> bool {
+        matches!(self, '\0'..='\x08' | '\x0B' | '\x0E'..='\x1F' | '\x7F')
     }
 
     fn is_gt_maximum_allowed_codepoint(self) -> bool {

--- a/css/parser/tokenization/token.rs
+++ b/css/parser/tokenization/token.rs
@@ -98,6 +98,34 @@ pub enum NumberFlag {
     Number,
 }
 
+// -------------- //
+// Implémentation //
+// -------------- //
+
+impl CSSToken {
+    pub(crate) fn define_hash_flag(mut self, flag: HashFlag) -> Self {
+        assert!(matches!(self, CSSToken::Hash(_, _)));
+
+        if let CSSToken::Hash(_, ref mut current_flag) = self {
+            *current_flag = flag;
+        }
+
+        self
+    }
+
+    pub(crate) fn define_hash_value(
+        mut self,
+        value: impl ToString,
+    ) -> Self {
+        assert!(matches!(self, CSSToken::Hash(_, _)));
+
+        if let CSSToken::Hash(ref mut current_value, _) = self {
+            *current_value = value.to_string();
+        }
+
+        self
+    }
+}
 
 // -------------- //
 // Implémentation // -> Interface

--- a/css/parser/tokenization/token.rs
+++ b/css/parser/tokenization/token.rs
@@ -73,9 +73,9 @@ pub enum CSSToken {
     /// Caractère ','
     Comma,
     /// Caractère '['
-    LeftBracket,
+    LeftSquareBracket,
     /// Caractère ']'
-    RightBracket,
+    RightSquareBracket,
     /// Caractère '('
     LeftParenthesis,
     /// Caractère ')'

--- a/css/parser/tokenization/token.rs
+++ b/css/parser/tokenization/token.rs
@@ -99,35 +99,6 @@ pub enum NumberFlag {
 }
 
 // -------------- //
-// Implémentation //
-// -------------- //
-
-impl CSSToken {
-    pub(crate) fn define_hash_flag(mut self, flag: HashFlag) -> Self {
-        assert!(matches!(self, CSSToken::Hash(_, _)));
-
-        if let CSSToken::Hash(_, ref mut current_flag) = self {
-            *current_flag = flag;
-        }
-
-        self
-    }
-
-    pub(crate) fn define_hash_value(
-        mut self,
-        value: impl ToString,
-    ) -> Self {
-        assert!(matches!(self, CSSToken::Hash(_, _)));
-
-        if let CSSToken::Hash(ref mut current_value, _) = self {
-            *current_value = value.to_string();
-        }
-
-        self
-    }
-}
-
-// -------------- //
 // Implémentation // -> Interface
 // -------------- //
 

--- a/css/parser/tokenization/token.rs
+++ b/css/parser/tokenization/token.rs
@@ -2,6 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+// --------- //
+// Structure //
+// --------- //
+
+#[derive(Debug)]
+#[derive(Default)]
+#[derive(PartialEq, Eq)]
+pub struct DimensionUnit(String);
+
 // ----------- //
 // Énumération //
 // ----------- //
@@ -46,7 +55,8 @@ pub enum CSSToken {
 
     /// Les `<dimension-token>` ont en outre une unité composée d'un ou
     /// plusieurs points de code.
-    Dimension(f64, NumberFlag, String),
+    Dimension(f64, NumberFlag, DimensionUnit),
+
     Whitespace,
 
     /// Suite de points de code "<!--"
@@ -99,7 +109,19 @@ pub enum NumberFlag {
 }
 
 // -------------- //
+// Implémentation //
+// -------------- //
+
+impl DimensionUnit {
+    pub fn new(unit: String) -> Self {
+        Self(unit)
+    }
+}
+
+// -------------- //
 // Implémentation // -> Interface
 // -------------- //
 
+// NOTE(phisyx): obligé de faire ceci à cause du type f64 dans notre
+//               énumération.
 impl Eq for CSSToken {}

--- a/css/parser/tokenization/token.rs
+++ b/css/parser/tokenization/token.rs
@@ -81,9 +81,9 @@ pub enum CSSToken {
     /// Caractère ')'
     RightParenthesis,
     /// Caractère '{'
-    LeftBrace,
+    LeftCurlyBracket,
     /// Caractère '}'
-    RightBrace,
+    RightCurlyBracket,
 
     EOF,
 }

--- a/css/parser/tokenization/token.rs
+++ b/css/parser/tokenization/token.rs
@@ -6,6 +6,8 @@
 // Structure //
 // --------- //
 
+use infra::primitive::codepoint::CodePoint;
+
 #[derive(Debug)]
 #[derive(Default)]
 #[derive(PartialEq, Eq)]
@@ -111,6 +113,20 @@ pub enum NumberFlag {
 // -------------- //
 // Implémentation //
 // -------------- //
+
+impl CSSToken {
+    pub(crate) fn append_character(&mut self, ch: CodePoint) {
+        match self {
+            | Self::Ident(s)
+            | Self::Function(s)
+            | Self::AtKeyword(s)
+            | Self::Hash(s, _)
+            | Self::Url(s)
+            | Self::String(s) => s.push(ch),
+            | _ => (),
+        }
+    }
+}
 
 impl DimensionUnit {
     pub fn new(unit: String) -> Self {

--- a/css/parser/tokenization/tokenizer.rs
+++ b/css/parser/tokenization/tokenizer.rs
@@ -544,6 +544,15 @@ where
             //
             // Retourner un <}-token>.
             | Some('}') => Some(CSSToken::RightCurlyBracket),
+
+            // digit
+            //
+            // Re-consommer le point de code d'entrée actuel, consommer un
+            // jeton numérique et le retourner.
+            | Some(ch) if ch.is_css_digit() => {
+                self.stream.rollback();
+                self.consume_numeric_token()
+            }
             // Anything else
             | _ => self.stream.current.map(CSSToken::Delim),
         }

--- a/css/parser/tokenization/tokenizer.rs
+++ b/css/parser/tokenization/tokenizer.rs
@@ -236,7 +236,7 @@ where
                 //
                 // Il s'agit d'une erreur d'analyse. Re-consommer le
                 // point de code d'entrée actuel, créer un
-                // <bad-string-token> et le renvoyer.
+                // <bad-string-token> et le retourner.
                 | Some(ch) if ch.is_newline() => {
                     // TODO(phisyx): gérer l'erreur.
                     self.stream.rollback();
@@ -370,7 +370,7 @@ where
             //
             // Si le flux d'entrée commence par un nombre, nous devons
             // reprendre le point de code d'entrée actuel, consommer un
-            // jeton numérique et le renvoyer.
+            // jeton numérique et le retourner.
             | Some('+')
                 if check_3_codepoints_would_start_a_number(
                     self.stream.next_n_input_character(3),
@@ -395,7 +395,7 @@ where
             //
             // Si le flux d'entrée commence par un nombre, nous devons
             // re-consommer le point de code d'entrée actuel, consommer un
-            // jeton numérique et le renvoyer.
+            // jeton numérique et le retourner.
             | Some('-')
                 if check_3_codepoints_would_start_a_number(
                     self.stream.next_n_input_character(3),
@@ -435,6 +435,26 @@ where
             // Retourner un <delim-token> dont la valeur est fixée au
             // point de code d'entrée actuel.
             | Some('-') => self.stream.current.map(CSSToken::Delim),
+
+            // U+002E FULL STOP (.)
+            //
+            // Si le flux d'entrée commence par un nombre, nous devons
+            // re-consommer le point de code d'entrée actuel, consommer un
+            // jeton numérique et le retourner.
+            | Some('.')
+                if check_3_codepoints_would_start_a_number(
+                    self.stream.next_n_input_character(3),
+                ) =>
+            {
+                self.stream.rollback();
+                self.consume_numeric_token()
+            }
+
+            // U+002E FULL STOP (.)
+            //
+            // Retourner un <delim-token> dont la valeur est fixée au
+            // point de code d'entrée actuel.
+            | Some('.') => self.stream.current.map(CSSToken::Delim),
             // Anything else
             | _ => self.stream.current.map(CSSToken::Delim),
         }
@@ -484,8 +504,8 @@ where
             // nous devons le consommer. Interpréter les chiffres
             // hexadécimaux comme un nombre hexadécimal. Si ce nombre est
             // zéro, ou s'il s'agit d'un substitut, ou s'il est supérieur
-            // au point de code maximum autorisé, renvoyer U+FFFD
-            // REPLACEMENT CHARACTER (�). Sinon, renvoyer le point de code
+            // au point de code maximum autorisé, retourner U+FFFD
+            // REPLACEMENT CHARACTER (�). Sinon, retourner le point de code
             // avec cette valeur.
             | Some(ch) if ch.is_ascii_hexdigit() => {
                 const HEXARADIX: u32 = 16;
@@ -532,7 +552,7 @@ where
 
             // EOF
             //
-            // Il s'agit d'une erreur d'analyse. Renvoyer U+FFFD
+            // Il s'agit d'une erreur d'analyse. Retourner U+FFFD
             // REPLACEMENT CHARACTER (�).
             // TODO(phisyx): gérer cette erreur d'analyse.
             | None => CodePoint::REPLACEMENT_CHARACTER,
@@ -603,7 +623,7 @@ where
                 // Consommer autant d'espace blanc que possible. Si le
                 // prochain point de code d'entrée est U+0029 RIGHT
                 // PARENTHESIS ()) ou EOF, nous devons le consommer et
-                // renvoyer le <url-token> (si EOF a été rencontré, c'est
+                // retourner le <url-token> (si EOF a été rencontré, c'est
                 // une erreur d'analyse) ; sinon, nous devons consommer les
                 // restes d'une mauvaise url, créer un <bad-url-token>, et
                 // le retourner.

--- a/css/parser/tokenization/tokenizer.rs
+++ b/css/parser/tokenization/tokenizer.rs
@@ -553,6 +553,15 @@ where
                 self.stream.rollback();
                 self.consume_numeric_token()
             }
+
+            // ident-start code point
+            //
+            // Re-consommer le point de code d'entrée actuel, consommer un
+            // jeton de type ident-like, et le retourner.
+            | Some(ch) if ch.is_ident_start_codepoint() => {
+                self.stream.rollback();
+                self.consume_ident_like_token()
+            }
             // Anything else
             | _ => self.stream.current.map(CSSToken::Delim),
         }

--- a/css/parser/tokenization/tokenizer.rs
+++ b/css/parser/tokenization/tokenizer.rs
@@ -157,6 +157,7 @@ where
 
         Some(CSSToken::String(string))
     }
+
     fn consume_token(&mut self) -> Option<CSSToken> {
         // Consume comments.
         self.consume_comments();
@@ -231,6 +232,16 @@ where
 
                 self.stream.current.map(CSSToken::Delim)
             }
+
+            // U+0028 LEFT PARENTHESIS (()
+            //
+            // Consomme un jeton de type <(-token>.
+            | Some('(') => Some(CSSToken::LeftParenthesis),
+
+            // U+0029 RIGHT PARENTHESIS ())
+            //
+            // Retourne un <)-token>.
+            | Some(')') => Some(CSSToken::RightParenthesis),
             // Anything else
             | _ => self.stream.current.map(CSSToken::Delim),
         }
@@ -399,6 +410,7 @@ fn check_3_codepoints_would_start_an_ident_sequence(
         | _ => false,
     }
 }
+
 /// Vérifie si deux points de code constituent un échappement valide.
 fn check_2_codepoints_are_a_valid_escape(
     maybe_valid_escape: impl AsRef<str>,

--- a/css/parser/tokenization/tokenizer.rs
+++ b/css/parser/tokenization/tokenizer.rs
@@ -455,6 +455,11 @@ where
             // Retourner un <delim-token> dont la valeur est fixée au
             // point de code d'entrée actuel.
             | Some('.') => self.stream.current.map(CSSToken::Delim),
+
+            // U+003A COLON (:)
+            //
+            // Retourner un <colon-token>.
+            | Some(':') => Some(CSSToken::Colon),
             // Anything else
             | _ => self.stream.current.map(CSSToken::Delim),
         }

--- a/css/parser/tokenization/tokenizer.rs
+++ b/css/parser/tokenization/tokenizer.rs
@@ -534,6 +534,16 @@ where
             //
             // Retourner un <]-token>.
             | Some(']') => Some(CSSToken::RightSquareBracket),
+
+            // U+007B LEFT CURLY BRACKET ({)
+            //
+            // Retourner un <{-token>.
+            | Some('{') => Some(CSSToken::LeftCurlyBracket),
+
+            // U+007D RIGHT CURLY BRACKET (})
+            //
+            // Retourner un <}-token>.
+            | Some('}') => Some(CSSToken::RightCurlyBracket),
             // Anything else
             | _ => self.stream.current.map(CSSToken::Delim),
         }

--- a/css/parser/tokenization/tokenizer.rs
+++ b/css/parser/tokenization/tokenizer.rs
@@ -483,6 +483,27 @@ where
             // Retourner un <delim-token> dont la valeur est fixée au
             // point de code d'entrée actuel.
             | Some('<') => self.stream.current.map(CSSToken::Delim),
+
+            // U+0040 COMMERCIAL AT (@)
+            //
+            // Si les 3 points de code d'entrée qui suivent démarrent une
+            // séquence d'identification, consommer une séquence
+            // d'identification, créer un <at-keyword-token> avec sa
+            // valeur définie sur la valeur renvoyée, et le retourner.
+            | Some('@')
+                if check_3_codepoints_would_start_an_ident_sequence(
+                    self.stream.next_n_input_character(3),
+                ) =>
+            {
+                self.stream.rollback();
+                CSSToken::AtKeyword(self.consume_ident_sequence()).into()
+            }
+
+            // U+0040 COMMERCIAL AT (@)
+            //
+            // Retourner un <delim-token> dont la valeur est fixée au
+            // point de code d'entrée actuel.
+            | Some('@') => self.stream.current.map(CSSToken::Delim),
             // Anything else
             | _ => self.stream.current.map(CSSToken::Delim),
         }

--- a/css/parser/tokenization/tokenizer.rs
+++ b/css/parser/tokenization/tokenizer.rs
@@ -90,6 +90,16 @@ where
 
         // Consume the next input code point.
         match self.stream.consume_next_input_character() {
+            // whitespace
+            //
+            // Consomme autant d'espace blanc que possible. Retourne un
+            // <whitespace-token>.
+            | Some(ch) if ch.is_css_whitespace() => {
+                self.stream.advance_as_long_as(|next_ch| {
+                    next_ch.is_css_whitespace()
+                });
+                Some(CSSToken::Whitespace)
+            }
             // Anything else
             | _ => self.stream.current.map(CSSToken::Delim),
         }
@@ -121,5 +131,6 @@ mod tests {
 
         // NOTE: tester si le premier caractère n'est pas '/'
         //       actuellement le script retourne None.
+        assert_eq!(tokenizer.consume_token(), Some(CSSToken::Whitespace));
     }
 }

--- a/css/parser/tokenization/tokenizer.rs
+++ b/css/parser/tokenization/tokenizer.rs
@@ -509,6 +509,27 @@ where
             //
             // Retourner un <[-token>.
             | Some('[') => Some(CSSToken::LeftSquareBracket),
+
+            // U+005C REVERSE SOLIDUS (\)
+            //
+            // Si le flux d'entrée commence par un échappement valide, nous
+            // devons re-consommer le point de code d'entrée actuel,
+            // consommer un jeton de type ident-like, et le retourner.
+            | Some('\\')
+                if check_3_codepoints_would_start_an_ident_sequence(
+                    self.stream.next_n_input_character(3),
+                ) =>
+            {
+                self.stream.rollback();
+                self.consume_ident_like_token()
+            }
+
+            // U+005C REVERSE SOLIDUS (\)
+            //
+            // Retourner un <delim-token> dont la valeur est fixée au
+            // point de code d'entrée actuel.
+            | Some('\\') => self.stream.current.map(CSSToken::Delim),
+
             // U+005D RIGHT SQUARE BRACKET (])
             //
             // Retourner un <]-token>.

--- a/css/parser/tokenization/tokenizer.rs
+++ b/css/parser/tokenization/tokenizer.rs
@@ -562,6 +562,12 @@ where
                 self.stream.rollback();
                 self.consume_ident_like_token()
             }
+
+            // EOF
+            //
+            // Retourner un <EOF-token>.
+            | None => Some(CSSToken::EOF),
+
             // Anything else
             | _ => self.stream.current.map(CSSToken::Delim),
         }

--- a/css/parser/tokenization/tokenizer.rs
+++ b/css/parser/tokenization/tokenizer.rs
@@ -508,6 +508,58 @@ fn check_3_codepoints_would_start_an_ident_sequence(
     }
 }
 
+/// Vérifier si trois points de code permettent de commencer un numéro
+fn check_3_codepoints_would_start_a_number(
+    maybe_number: Cow<str>,
+) -> bool {
+    let mut chars = maybe_number.chars();
+
+    let first_codepoint = chars.next();
+    match first_codepoint {
+        // U+002B PLUS SIGN (+)
+        // U+002D HYPHEN-MINUS (-)
+        //
+        // Si le deuxième point de code est un chiffre, nous devons
+        // retourner true.
+        // Sinon, si le deuxième point de code est un U+002E FULL STOP (.)
+        // et le troisième point de code est un chiffre, nous devons
+        // retourner true.
+        // Sinon false.
+        | Some('+' | '-') => {
+            let second_codepoint = chars.next();
+            match second_codepoint {
+                | Some(ch) if ch.is_css_digit() => true,
+                | Some('.') => {
+                    let third_codepoint = chars.next();
+                    match third_codepoint {
+                        | Some(ch) if ch.is_css_digit() => true,
+                        | _ => false,
+                    }
+                }
+                | _ => false,
+            }
+        }
+
+        // U+002E FULL STOP (.)
+        //
+        // Si le deuxième point de code est un chifre, nous devons
+        // retourner true. Sinon false.
+        | Some('.') => {
+            let second_codepoint = chars.next();
+            match second_codepoint {
+                | Some(ch) if ch.is_css_digit() => true,
+                | _ => false,
+            }
+        }
+
+        // digit
+        | Some(ch) if ch.is_css_digit() => true,
+
+        // Anything else
+        | _ => false,
+    }
+}
+
 /// Vérifie si deux points de code constituent un échappement valide.
 fn check_2_codepoints_are_a_valid_escape(
     maybe_valid_escape: impl AsRef<str>,

--- a/css/parser/tokenization/tokenizer.rs
+++ b/css/parser/tokenization/tokenizer.rs
@@ -345,6 +345,11 @@ where
             // Retourner un <delim-token> dont la valeur est fixée
             // au point de code d'entrée actuel.
             | Some('+') => self.stream.current.map(CSSToken::Delim),
+
+            // U+002C COMMA (,)
+            //
+            // Retourner un <comma-token>.
+            | Some(',') => Some(CSSToken::Comma),
             // Anything else
             | _ => self.stream.current.map(CSSToken::Delim),
         }

--- a/css/parser/tokenization/tokenizer.rs
+++ b/css/parser/tokenization/tokenizer.rs
@@ -465,6 +465,24 @@ where
             //
             // Retourner un <semicolon-token>.
             | Some(';') => Some(CSSToken::Semicolon),
+
+            // U+003C LESS-THAN SIGN (<)
+            //
+            // Si les 3 points de code d'entrée suivants sont U+0021
+            // EXCLAMATION MARK U+002D HYPHEN-MINUS U+002D HYPHEN-MINUS
+            // (!--), les consommer et retourner un <CDO-token>.
+            | Some('<')
+                if self.stream.next_n_input_character(3) == "!--" =>
+            {
+                self.stream.advance(3);
+                Some(CSSToken::Cdo)
+            }
+
+            // U+003C LESS-THAN SIGN (<)
+            //
+            // Retourner un <delim-token> dont la valeur est fixée au
+            // point de code d'entrée actuel.
+            | Some('<') => self.stream.current.map(CSSToken::Delim),
             // Anything else
             | _ => self.stream.current.map(CSSToken::Delim),
         }

--- a/css/parser/tokenization/tokenizer.rs
+++ b/css/parser/tokenization/tokenizer.rs
@@ -460,6 +460,11 @@ where
             //
             // Retourner un <colon-token>.
             | Some(':') => Some(CSSToken::Colon),
+
+            // U+003B SEMICOLON (;)
+            //
+            // Retourner un <semicolon-token>.
+            | Some(';') => Some(CSSToken::Semicolon),
             // Anything else
             | _ => self.stream.current.map(CSSToken::Delim),
         }

--- a/css/parser/tokenization/tokenizer.rs
+++ b/css/parser/tokenization/tokenizer.rs
@@ -504,6 +504,15 @@ where
             // Retourner un <delim-token> dont la valeur est fixée au
             // point de code d'entrée actuel.
             | Some('@') => self.stream.current.map(CSSToken::Delim),
+
+            // U+005B LEFT SQUARE BRACKET ([)
+            //
+            // Retourner un <[-token>.
+            | Some('[') => Some(CSSToken::LeftSquareBracket),
+            // U+005D RIGHT SQUARE BRACKET (])
+            //
+            // Retourner un <]-token>.
+            | Some(']') => Some(CSSToken::RightSquareBracket),
             // Anything else
             | _ => self.stream.current.map(CSSToken::Delim),
         }

--- a/css/parser/tokenization/tokenizer.rs
+++ b/css/parser/tokenization/tokenizer.rs
@@ -339,6 +339,12 @@ where
                 self.stream.rollback();
                 self.consume_numeric_token()
             }
+
+            // U+002B PLUS SIGN (+)
+            //
+            // Retourner un <delim-token> dont la valeur est fixée
+            // au point de code d'entrée actuel.
+            | Some('+') => self.stream.current.map(CSSToken::Delim),
             // Anything else
             | _ => self.stream.current.map(CSSToken::Delim),
         }

--- a/dom/node/document.rs
+++ b/dom/node/document.rs
@@ -67,7 +67,6 @@ impl Document {
         }
     }
 
-    /// todo: FIXME
     pub fn create_element(
         local_name: impl AsRef<str>,
         options: Option<CreateElementOptions>,

--- a/dom/node/element.rs
+++ b/dom/node/element.rs
@@ -23,7 +23,7 @@ use super::{document_fragment::DocumentFragmentNode, DocumentNode};
 #[derive(Debug)]
 pub struct Element {
     inner: HTMLElement,
-    // todo: changer en NamedNodeMap (cf. https://dom.spec.whatwg.org/#namednodemap)
+    // TODO(phisyx): changer le type de cet attribut en NamedNodeMap (cf. https://dom.spec.whatwg.org/#namednodemap)
     pub attributes: RwLock<HashMap<DOMString, DOMString>>,
     pub id: RwLock<Option<DOMString>>,
     pub is: RwLock<Option<DOMString>>,

--- a/dom/node/mod.rs
+++ b/dom/node/mod.rs
@@ -147,7 +147,8 @@ impl Node {
     }
 
     /// Retourne la donnée du noeud, qui est l'élément courant.
-    // FIXME: au lieux de panic comme un demeuré: mieux gérer les erreurs.
+    // NOTE(phisyx): au lieux de panic comme un demeuré: mieux gérer les
+    // erreurs.
     pub fn element_ref(&self) -> &Element {
         match self.node_data.as_ref() {
             | Some(NodeData::Element(element)) => element,
@@ -156,7 +157,8 @@ impl Node {
     }
 
     /// Retourne la donnée du noeud, qui est le document courant.
-    // FIXME: au lieux de panic comme un demeuré: mieux gérer les erreurs.
+    // NOTE(phisyx): au lieux de panic comme un demeuré: mieux gérer les
+    // erreurs.
     pub fn document_ref(&self) -> &Document {
         match self.node_data.as_ref() {
             | Some(NodeData::Document(ref d)) => d,
@@ -165,7 +167,8 @@ impl Node {
     }
 
     /// Retourne la donnée du noeud, qui est l'élément script.
-    // FIXME: au lieux de panic comme un demeuré: mieux gérer les erreurs.
+    // NOTE(phisyx): au lieux de panic comme un demeuré: mieux gérer les
+    // erreurs.
     pub fn script_ref(&self) -> &HTMLScriptElement<DocumentNode> {
         match self.node_data.as_ref() {
             | Some(NodeData::Element(element)) => element.script(),
@@ -175,7 +178,8 @@ impl Node {
 
     /// Défini une suite de caractères au noeud courant dans lequel nous
     /// pouvons définir des [données de caractères](CharacterData).
-    // FIXME: au lieux de panic comme un demeuré: mieux gérer les erreurs.
+    // NOTE(phisyx): au lieux de panic comme un demeuré: mieux gérer les
+    // erreurs.
     pub fn set_data(&self, data: &str) {
         match self.node_data.as_ref() {
             | Some(NodeData::CharacterData(cd)) => cd.set_data(data),

--- a/html/parser/error.rs
+++ b/html/parser/error.rs
@@ -146,10 +146,10 @@ define_errors! {
     /// à l'intérieur du contenu d'un élément de script (par exemple,
     /// `<script><!-- foo`).
     ///
-    /// Note: les structures syntaxiques qui ressemblent à des commentaires
-    /// HTML dans les éléments de script sont analysées comme du contenu
-    /// textuel. Elles peuvent faire partie d'une structure syntaxique
-    /// spécifique au langage de script ou être traitées comme un
+    /// NOTE(html): les structures syntaxiques qui ressemblent à des
+    /// commentaires HTML dans les éléments de script sont analysées comme
+    /// du contenu textuel. Elles peuvent faire partie d'une structure
+    /// syntaxique spécifique au langage de script ou être traitées comme un
     /// commentaire de type HTML, si le langage de script les prend en
     /// charge (par exemple, les règles d'analyse des commentaires de type
     /// HTML se trouvent à l'annexe B de la spécification JavaScript). La
@@ -171,8 +171,8 @@ define_errors! {
     /// présent) ou jusqu'à la fin du flux d'entrée est traité comme un
     /// commentaire.
     ///
-    /// Note: une cause possible de cette erreur est l'utilisation d'une
-    /// déclaration de balisage XML (par exemple, `<!ELEMENT br EMPTY>`)
+    /// NOTE(html): une cause possible de cette erreur est l'utilisation
+    /// d'une déclaration de balisage XML (par exemple, `<!ELEMENT br EMPTY>`)
     /// dans l'HTML.
     IncorrectlyOpenedComment = "incorrectly-opened-comment",
 
@@ -210,7 +210,7 @@ define_errors! {
     ///         |- #text: <42>
     ///         |- #comment: 42
     ///
-    /// Note: alors que le premier point de code d'un nom de balise est
+    /// NOTE(html): alors que le premier point de code d'un nom de balise est
     /// limité à un alpha ASCII, un large éventail de points de code (y
     /// compris des chiffres ASCII) est autorisé dans les positions
     /// suivantes.
@@ -340,7 +340,7 @@ define_errors! {
     /// d'attribut. L'analyseur syntaxique inclut ces points de code dans
     /// le nom de l'attribut.
     ///
-    /// Note: les points de code qui déclenchent cette erreur font
+    /// NOTE(html): les points de code qui déclenchent cette erreur font
     /// généralement partie d'une autre construction syntaxique et peuvent
     /// être le signe d'une faute de frappe autour du nom de l'attribut.
     ///
@@ -361,12 +361,12 @@ define_errors! {
     /// U+0060 (`) dans une valeur d'attribut (unquoted). L'analyseur
     /// syntaxique inclut ces points de code dans la valeur de l'attribut.
     ///
-    /// Note 1: les points de code qui déclenchent cette erreur font
+    /// NOTE(html) 1: les points de code qui déclenchent cette erreur font
     /// généralement partie d'une autre construction syntaxique et peuvent
     /// être le signe d'une faute de frappe autour de la valeur de
     /// l'attribut.
     ///
-    /// Note 2: U+0060 (`) figure dans la liste des points de code qui
+    /// NOTE(html) 2: U+0060 (`) figure dans la liste des points de code qui
     /// déclenchent cette erreur parce que certains agents utilisateurs
     /// anciens le traitent comme un guillemet.
     ///
@@ -380,7 +380,7 @@ define_errors! {
     /// l'analyseur syntaxique traite U+003D (=) comme le premier point de
     /// code du nom de l'attribut.
     ///
-    /// Note: la raison courante de cette erreur est un nom d'attribut
+    /// NOTE(html): la raison courante de cette erreur est un nom d'attribut
     /// oublié.
     ///
     /// Example: `<div foo="bar" ="baz">`
@@ -413,8 +413,8 @@ define_errors! {
     ///      | - head
     ///      | - body
     ///
-    /// Note: la raison courante de cette erreur est une instruction de
-    /// traitement XML (par exemple, `<?xml-stylesheet type="text/css"
+    /// NOTE(html): la raison courante de cette erreur est une instruction
+    /// de traitement XML (par exemple, `<?xml-stylesheet type="text/css"
     /// href="style.css"?>`) ou une déclaration XML (par exemple, `<?xml
     /// version="1.0" encoding="UTF-8"?>`) utilisée dans HTML.
     UnexpectedQuestionMarkInsteadOfTagName = "unexpected-question-mark-instead-of-tag-name",

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -71,7 +71,7 @@ where
         loop {
             let token = self.tokenizer.next_token();
 
-            // todo: améliorer cette partie-ci.
+            // TODO(phisyx): à améliorer ASAP.
             match self.tokenizer.tree_construction.dispatcher(token) {
                 | ControlFlow::Continue(HTMLParserState::SwitchTo(
                     state,
@@ -95,7 +95,7 @@ where
                     }
                 }
 
-                // todo(fixme): à améliorer asap.
+                // TODO(phisyx): à améliorer ASAP.
                 | ControlFlow::Continue(HTMLParserState::CustomRcdata) => {
                     if let Some(HTMLToken::Character('\n')) =
                         self.tokenizer.next_token()
@@ -125,8 +125,8 @@ where
                     continue;
                 }
 
-                | ControlFlow::Break(HTMLParserFlag::Pause) => break, /* todo */
-                | ControlFlow::Break(HTMLParserFlag::Stop) => break, /* todo */
+                | ControlFlow::Break(HTMLParserFlag::Pause) => break, /* Voir TODO ci-haut */
+                | ControlFlow::Break(HTMLParserFlag::Stop) => break, /* Voir TODO ci-haut */
             }
         }
     }

--- a/html/parser/tree_construction/mod.rs
+++ b/html/parser/tree_construction/mod.rs
@@ -439,7 +439,9 @@ impl HTMLTreeConstruction {
                 }
             }
 
-            | _ => todo!(),
+            // NOTE(phisyx): la spécification n'indique pas de traitement
+            //               pour les autres types de jetons.
+            | _ => unreachable!(),
         };
 
         HTMLTreeConstructionControlFlow::Continue(
@@ -699,8 +701,8 @@ impl HTMLTreeConstruction {
     ///    2.1. Si le `foster parenting` est activée et que la cible est
     /// un élément table, tbody, tfoot, thead ou tr.
     ///
-    ///    Note: Le `foster parenting` se produit lorsque le contenu est
-    /// mal intégré dans les table's.
+    ///    NOTE(html): Le `foster parenting` se produit lorsque le contenu
+    /// est mal intégré dans les table's.
     ///
     ///      2.1.1. Le dernier template est le dernier élément template
     /// dans la pile d'éléments ouverts, s'il y en a.
@@ -734,11 +736,11 @@ impl HTMLTreeConstruction {
     /// l'intérieur de l'élément précédent, après son dernier enfant (le
     /// cas échéant).
     ///
-    ///    Note: Ces étapes sont nécessaires en partie parce qu'il est
-    /// possible que des éléments, en particulier l'élément table dans ce
-    /// cas, aient été déplacés par un script dans le DOM, ou même
-    /// entièrement retirés du DOM, après que l'élément ait été inséré par
-    /// l'analyseur.
+    ///    NOTE(html): Ces étapes sont nécessaires en partie parce qu'il
+    /// est possible que des éléments, en particulier l'élément table
+    /// dans ce cas, aient été déplacés par un script dans le DOM, ou
+    /// même entièrement retirés du DOM, après que l'élément ait été
+    /// inséré par l'analyseur.
     ///
     ///    2.2. Sinon : l'emplacement d'insertion ajusté doit être à
     /// l'intérieur de la cible, après son dernier enfant (s'il y en a).
@@ -1131,7 +1133,7 @@ impl HTMLTreeConstruction {
     /// ont été ouverts dans le body, cell ou caption courant (selon le
     /// plus jeune) et qui n'ont pas été explicitement fermés.
     ///
-    /// Note: La liste des éléments de formatage actifs est toujours
+    /// NOTE(html): La liste des éléments de formatage actifs est toujours
     /// constituée d'éléments dans l'ordre chronologique, l'élément le
     /// moins récemment ajouté étant le premier et l'élément le plus
     /// récemment ajouté le dernier (sauf pendant l'exécution des étapes 7
@@ -1163,7 +1165,8 @@ impl HTMLTreeConstruction {
             return;
         };
 
-        // todo: probablement à améliorer.
+        // NOTE(phisyx): code qui est à propice à des bugs; à améliorer et
+        //               à tester.
         #[allow(unused_labels)]
         'main: loop {
             // Rewind

--- a/html/parser/tree_construction/rules/body.rs
+++ b/html/parser/tree_construction/rules/body.rs
@@ -999,10 +999,11 @@ impl HTMLTreeConstruction {
             // Insérer un élément HTML pour le jeton.
             // Passer le tokenizer à l'état PLAINTEXT.
             //
-            // Note: Une fois qu'une balise de début avec le nom de balise
-            // "plaintext" a été vue, ce sera le dernier jeton vu autre que
-            // les jetons de caractères (et le jeton de fin de fichier),
-            // car il n'y a aucun moyen de sortir de l'état PLAINTEXT.
+            // NOTE(html): Une fois qu'une balise de début avec le nom de
+            // balise "plaintext" a été vue, ce sera le dernier jeton vu
+            // autre que les jetons de caractères (et le jeton de fin de
+            // fichier), car il n'y a aucun moyen de sortir de l'état
+            // PLAINTEXT.
             #[allow(deprecated)]
             | HTMLToken::Tag {
                 ref name,
@@ -1808,7 +1809,7 @@ impl HTMLTreeConstruction {
                 ..
             } if tag_names::textarea == name => {
                 self.insert_html_element(token.as_tag());
-                // todo(fixme): améliorer cette partie ci.
+                // TODO(phisyx): améliorer cette partie ci.
                 return HTMLTreeConstructionControlFlow::Continue(
                     HTMLParserState::CustomRcdata,
                 );
@@ -1997,8 +1998,8 @@ impl HTMLTreeConstruction {
                 self.insert_html_element(token.as_tag());
             }
 
-            // todo: A start tag whose tag name is one of: "math"
-            // todo: A start tag whose tag name is one of: "svg"
+            // TODO(html): A start tag whose tag name is one of: "math"
+            // TODO(html): A start tag whose tag name is one of: "svg"
 
             // A start tag whose tag name is one of: "caption", "col",
             // "colgroup", "frame", "head", "tbody", "td", "tfoot", "th",
@@ -2034,7 +2035,7 @@ impl HTMLTreeConstruction {
             // a.
             // Insérer un élément HTML pour le jeton.
             //
-            // Note: Cet élément sera un élément ordinaire.
+            // NOTE(html): Cet élément sera un élément ordinaire.
             | HTMLToken::Tag { is_end: false, .. } => {
                 self.reconstruct_active_formatting_elements();
                 self.insert_html_element(token.as_tag());

--- a/html/parser/tree_construction/rules/frameset.rs
+++ b/html/parser/tree_construction/rules/frameset.rs
@@ -143,8 +143,8 @@ impl HTMLTreeConstruction {
             //
             // Si le nœud actuel n'est pas l'élément html racine, il s'agit
             // d'une erreur d'analyse.
-            // Note: Le nœud actuel ne peut être que l'élément html racine
-            // dans le cas d'un fragment.
+            // NOTE(html): Le nœud actuel ne peut être que l'élément html
+            // racine dans le cas d'un fragment.
             // Arrêter l'analyse.
             | HTMLToken::EOF => {
                 if let Some(cnode) = self.current_node() {

--- a/html/parser/tree_construction/rules/head.rs
+++ b/html/parser/tree_construction/rules/head.rs
@@ -196,7 +196,7 @@ impl HTMLTreeConstruction {
             // Accuser réception du drapeau d'auto-fermeture du jeton, s'il
             // est activé.
             //
-            // TODO:
+            // TODO(html):
             // Si l'analyseur HTML spéculatif actif est nul, alors :
             //
             //   1. Si l'élément possède un attribut charset, et que
@@ -214,9 +214,10 @@ impl HTMLTreeConstruction {
             // confiance est actuellement provisoire, alors nous devons
             // changer l'encodage pour l'encodage extrait.
             //
-            // Note: L'analyseur HTML spéculatif n'applique pas de manière
-            // spéculative les déclarations de codage des caractères afin
-            // de réduire la complexité de l'implémentation.
+            // NOTE(html): L'analyseur HTML spéculatif n'applique pas de
+            // manière spéculative les déclarations de codage des
+            // caractères afin de réduire la complexité de
+            // l'implémentation.
             | HTMLToken::Tag {
                 ref name,
                 is_end: false,
@@ -318,12 +319,12 @@ impl HTMLTreeConstruction {
                     script_element.set_already_started(true);
                 }
 
-                // todo(document.write/ln): Si l'analyseur syntaxique a été
-                // invoqué par l'intermédiaire des méthodes
-                // document.write() ou document.writeln(), il est possible
-                // de marquer l'élément script comme "déjà lancé". (Par
-                // exemple, l'agent utilisateur peut utiliser cette clause
-                // pour empêcher l'exécution de scripts d'origine croisée
+                // TODO(html): Si l'analyseur syntaxique a été invoqué
+                // par l'intermédiaire des méthodes `document.write()` ou
+                // `document.writeln()`, il est possible de marquer
+                // l'élément script comme "déjà lancé". (Par exemple,
+                // l'agent utilisateur peut utiliser cette clause pour
+                // empêcher l'exécution de scripts d'origine croisée
                 // insérés via document.write() dans des conditions de
                 // réseau lent, ou lorsque le chargement de la page a déjà
                 // pris beaucoup de temps).
@@ -690,8 +691,8 @@ impl HTMLTreeConstruction {
             // de la pile des éléments ouverts. (Il se peut que ce ne soit
             // pas le nœud actuel à ce stade).
             //
-            // Note: le pointeur de l'élément de tête ne peut pas être nul
-            // à ce stade.
+            // NOTE(html): le pointeur de l'élément de tête ne peut pas
+            // être nul à ce stade.
             #[allow(deprecated)]
             | HTMLToken::Tag {
                 ref name,

--- a/html/parser/tree_construction/rules/initial.rs
+++ b/html/parser/tree_construction/rules/initial.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 
 impl HTMLTreeConstruction {
-    // TODO: si le document n'est pas un document iframe srcdoc
+    // TODO(html): si le document n'est pas un document iframe srcdoc
     pub(crate) fn handle_initial_insertion_mode(
         &mut self,
         token: HTMLToken,
@@ -56,9 +56,9 @@ impl HTMLTreeConstruction {
             // le [HTMLToken::DOCTYPE], ou la chaîne de caractères vide si
             // l'identifiant système est manquant.
             //
-            // Note: cela garantit également que le noeud [DocumentType]
-            // est renvoyé comme valeur de l'attribut doctype de l'objet
-            // [Document].
+            // NOTE(html): cela garantit également que le noeud
+            // [DocumentType] est renvoyé comme valeur de l'attribut
+            // doctype de l'objet [Document].
             //
             // Ensuite, si le document n'est pas un document iframe srcdoc,
             // et que l'analyseur syntaxique ne peut pas changer le drapeau

--- a/html/parser/tree_construction/rules/select.rs
+++ b/html/parser/tree_construction/rules/select.rs
@@ -184,7 +184,7 @@ impl HTMLTreeConstruction {
             // ce qu'un élément select ait été retiré de la pile.
             // Réinitialiser le mode d'insertion de manière appropriée.
             //
-            // Note: Il est juste traité comme une balise de fin.
+            // NOTE(html): Il est juste traité comme une balise de fin.
             | HTMLToken::Tag {
                 ref name,
                 is_end: true,

--- a/html/parser/tree_construction/rules/text.rs
+++ b/html/parser/tree_construction/rules/text.rs
@@ -22,9 +22,9 @@ impl HTMLTreeConstruction {
             //
             // Insérer le caractère du jeton.
             //
-            // Note: il ne peut jamais s'agir d'un caractère U+0000 NULL ;
-            // le tokenizer les convertit en caractères
-            // U+FFFD REPLACEMENT CHARACTER.
+            // NOTE(html): il ne peut jamais s'agir d'un caractère U+0000
+            // NULL ; le tokenizer les convertit en caractères U+FFFD
+            // REPLACEMENT CHARACTER.
             | HTMLToken::Character(ch) => {
                 self.insert_character(ch);
             }
@@ -56,14 +56,14 @@ impl HTMLTreeConstruction {
                 );
             }
 
-            // TODO: active spéculative html tree
+            // TODO(html): active spéculative html tree
             // An end tag whose tag name is "script"
             | HTMLToken::Tag {
                 ref name,
                 is_end: true,
                 ..
             } if tag_names::script == name => {
-                todo!()
+                todo!("active spéculative html tree")
             }
 
             // Any other end tag

--- a/infra/Cargo.toml
+++ b/infra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-infra"
-version = "0.1.6"
+version = "0.1.7"
 license-file = "../LICENSE"
 edition = "2021"
 

--- a/infra/structure/lists/peekable.rs
+++ b/infra/structure/lists/peekable.rs
@@ -21,6 +21,12 @@ where
     /// l'itération.
     ///
     /// Le type générique est obligatoire.
+    ///
+    /// NOTE(phisyx): ce type vaut None si la position demandée est
+    /// supérieure à la longueur de l'itération, tant bien qu'il y ait
+    /// des éléments à l'intérieur du flux. Exemple: si `lookahead_offset`
+    /// vaut 5, et le flux a dans son flux `[0, 1, 2]` cela retournera
+    /// `None`.
     fn peek_until<R: FromIterator<I>>(
         &mut self,
         lookahead_offset: usize,

--- a/infra/structure/lists/queue.rs
+++ b/infra/structure/lists/queue.rs
@@ -34,6 +34,7 @@ impl<T, I> ListQueue<T, I> {
 impl<T, I> ListQueue<T, I>
 where
     T: Iterator<Item = I>,
+    I: Clone,
 {
     fn fill_queue_max(&mut self) {
         let stored_elements = self.queue.len();
@@ -66,6 +67,12 @@ where
 
     pub fn dequeue(&mut self) -> Option<T::Item> {
         self.queue.remove(0)
+    }
+
+    // NOTE(phisyx): ceci ajoute un élément au début de la queue.
+    pub fn rollback(&mut self, last_consumed_item: Option<T::Item>) {
+        let mut temp = vec![last_consumed_item];
+        self.queue.splice(..0, temp.drain(..));
     }
 }
 
@@ -114,6 +121,7 @@ where
 impl<T, I> Iterator for ListQueue<T, I>
 where
     T: Iterator<Item = I>,
+    I: Clone,
 {
     type Item = T::Item;
 

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-parser"
-version = "0.1.9"
+version = "0.1.10"
 license-file = "../LICENSE"
 edition = "2021"
 

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-parser"
-version = "0.1.8"
+version = "0.1.9"
 license-file = "../LICENSE"
 edition = "2021"
 
@@ -9,4 +9,4 @@ path = "./lib.rs"
 
 [dependencies]
 infra = { path = "../infra", package = "resworb-infra" }
-syntax = { version = "^0.15", package = "rowan" }
+# syntax = { version = "^0.15", package = "rowan" }

--- a/parser/lib.rs
+++ b/parser/lib.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-pub use syntax;
+// pub use syntax;
 
 /// Voir <https://html.spec.whatwg.org/multipage/parsing.html#the-input-byte-stream>
 pub mod decoder;

--- a/parser/preprocessor.rs
+++ b/parser/preprocessor.rs
@@ -77,6 +77,12 @@ where
         self.nth(n)
     }
 
+    pub fn advance_as_long_as(&mut self, predicate: impl Fn(&I) -> bool) {
+        while predicate(self.meanwhile().peek().unwrap()) {
+            self.advance(1);
+        }
+    }
+
     /// Permet de revenir en arrière dans le flux.
     pub fn rollback(&mut self) {
         self.is_replayed = true;

--- a/parser/preprocessor.rs
+++ b/parser/preprocessor.rs
@@ -15,7 +15,7 @@ use infra::{
 
 pub type InputStream<T, I> = InputStreamPreprocessor<T, I>;
 
-// NOTE: améliorer ce type.
+// NOTE(phisyx): améliorer ce type.
 type PreScanFn<I> = fn(Option<I>) -> Option<I>;
 
 // --------- //
@@ -77,10 +77,26 @@ where
         self.nth(n)
     }
 
-    pub fn advance_as_long_as(&mut self, predicate: impl Fn(&I) -> bool) {
-        while predicate(self.meanwhile().peek().unwrap()) {
-            self.advance(1);
+    // NOTE(phisyx): utiliser un générique pour le second paramètre?
+    pub fn advance_as_long_as(
+        &mut self,
+        predicate: impl Fn(&I) -> bool,
+        with_limit: Option<usize>,
+    ) -> Vec<I> {
+        let mut limit = with_limit.map(|n| n + 1).unwrap_or(0);
+        let mut result = vec![];
+
+        // NOTE(phisyx): code qui peut être amélioré.
+        while (self.meanwhile().peek().is_some()
+            && predicate(self.meanwhile().peek().unwrap()))
+            && (limit > 0 || with_limit.is_none())
+        {
+            result.push(self.advance(1).unwrap());
+            if with_limit.is_some() {
+                limit -= 1;
+            }
         }
+        result
     }
 
     /// Permet de revenir en arrière dans le flux.


### PR DESCRIPTION
- feat(css): consume comments #76
- feat(css): point de code espace blanc #76
- feat(css): point de code `"` et `'`, consomme le jeton de chaîne de caractères #76
- feat(css): point de code `#` number sign #76
- feat(css): point de code `(`/`)` parenthèses #76
- feat(css): point de code `+` plus sign #76
- fix(css): point de code `+` plus sign
- feat(css): point de code `+` plus sign (cas par défaut) #76
- feat(css): point de code `,` #76
- feat(css): point de code `-` hyphen-minus #76
- feat(css): point de code `.` FULL STOP #76
- feat(css): point de code `:` COLON #76
- feat(css): point de code `;` SEMICOLON #76
- feat(css): point de code `<` LESS-THAN SIGN #76
- feat(css): point de code `@` COMERCIAL AT #76
- feat(css): point de code `[]` SQUARE BRACKET #76
- feat(css): point de code `\` REVERSE SOLIDUS #76
- feat(css): point de code `{}` CURLY BRACKET #76
- feat(css): point de code digit #76
- feat(css): point de code ident-start #76
- feat(css): jeton EOF #76
- chore: changement des commentaires TODO
