### PR TITLE
CSS Tokenization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ default-run = "resworb"
 
 [workspace]
 members = [
+    "css",
     "dom",
     "html",
     "html/elements",

--- a/css/Cargo.toml
+++ b/css/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "resworb-css"
+version = "0.1.0"
+license-file = "../LICENSE"
+edition = "2021"
+
+[lib]
+path = "./lib.rs"
+
+[dependencies]
+parser = { path = "./parser", package = "resworb-css-parser" }

--- a/css/lib.rs
+++ b/css/lib.rs
@@ -1,0 +1,5 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+pub use parser;

--- a/css/parser/Cargo.toml
+++ b/css/parser/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "resworb-css-parser"
+version = "0.1.0"
+license-file = "../LICENSE"
+edition = "2021"
+
+[lib]
+path = "./lib.rs"
+
+[dependencies]
+infra = { path = "../../infra", package = "resworb-infra" }
+parser = { path = "../../parser", package = "resworb-parser" }

--- a/css/parser/Cargo.toml
+++ b/css/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-css-parser"
-version = "0.1.0"
+version = "0.1.17"
 license-file = "../LICENSE"
 edition = "2021"
 

--- a/css/parser/Cargo.toml
+++ b/css/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-css-parser"
-version = "0.1.17"
+version = "0.1.18"
 license-file = "../LICENSE"
 edition = "2021"
 

--- a/css/parser/codepoint.rs
+++ b/css/parser/codepoint.rs
@@ -49,10 +49,29 @@ pub trait CSSCodePoint: Copy {
 
     /// Saut de ligne.
     ///
-    /// Note: U+000D CARRIAGE RETURN et U+000C FORM FEED ne sont pas inclus
-    /// dans cette définition, car ils sont convertis en U+000A LINE FEED
-    /// lors du prétraitement.
+    /// NOTE(css): U+000D CARRIAGE RETURN et U+000C FORM FEED ne sont pas
+    /// inclus dans cette définition, car ils sont convertis en U+000A LINE
+    /// FEED lors du prétraitement.
     fn is_newline(self) -> bool;
+
+    /// non-ASCII code point
+    ///
+    /// Un point de code dont la valeur est égale ou supérieure à U+0080
+    /// <control>
+    fn is_non_ascii_codepoint(self) -> bool;
+
+    /// non-printable code point
+    ///
+    /// Un point de code entre U+0000 NULL et U+0008 BACKSPACE inclus, ou
+    /// U+000B LINE TABULATION, ou un point de code entre U+000E SHIFT OUT
+    /// et U+001F INFORMATION SEPARATOR ONE inclus, ou U+007F DELETE.
+    fn is_non_printable_codepoint(self) -> bool;
+
+    /// maximum allowed code point
+    ///
+    /// Le plus grand point de code défini par Unicode : U+10FFFF.
+    fn is_gt_maximum_allowed_codepoint(self) -> bool;
+    fn is_lt_maximum_allowed_codepoint(self) -> bool;
 }
 
 // -------------- //
@@ -75,7 +94,7 @@ impl CSSCodePoint for CodePoint {
     }
 
     fn is_ident_start_codepoint(self) -> bool {
-        self.is_letter()
+        self.is_letter() || self.is_non_ascii_codepoint() || self == '_'
     }
 
     fn is_letter(self) -> bool {
@@ -92,5 +111,21 @@ impl CSSCodePoint for CodePoint {
 
     fn is_newline(self) -> bool {
         self == '\n'
+    }
+
+    fn is_non_ascii_codepoint(self) -> bool {
+        self as u32 >= 0x80
+    }
+
+    fn is_non_printable_codepoint(self) -> bool {
+        matches!(self, '\0'..='\x08' | '\x0B' | '\x0E'..='\x1F' | '\x7F')
+    }
+
+    fn is_gt_maximum_allowed_codepoint(self) -> bool {
+        self > '\u{10FFFF}'
+    }
+
+    fn is_lt_maximum_allowed_codepoint(self) -> bool {
+        self < '\u{10FFFF}'
     }
 }

--- a/css/parser/codepoint.rs
+++ b/css/parser/codepoint.rs
@@ -1,0 +1,96 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use infra::primitive::codepoint::CodePoint;
+
+// --------- //
+// Interface //
+// --------- //
+
+pub trait CSSCodePoint: Copy {
+    /// Chiffre
+    ///
+    /// Un point de code compris entre U+0030 DIGIT ZERO (0) et U+0039
+    /// DIGIT NINE (9) inclus.
+    fn is_css_digit(self) -> bool;
+
+    /// Espace blanc.
+    ///
+    /// Un saut de ligne, une TABULATION DE CARACTÈRES U+0009 ou un ESPACE
+    /// U+0020.
+    fn is_css_whitespace(self) -> bool;
+
+    /// ident code point
+    ///
+    /// Un point de code ident de début, un chiffre ou U+002D HYPHEN-MINUS
+    /// (-).
+    fn is_ident_codepoint(self) -> bool;
+
+    /// ident-start code point
+    ///
+    /// Une lettre, un point de code non ASCII ou U+005F LOW LINE (_).
+    fn is_ident_start_codepoint(self) -> bool;
+
+    /// Lettre
+    ///
+    /// Une lettre majuscule ou une lettre minuscule.
+    fn is_letter(self) -> bool;
+
+    /// Lettre minuscule
+    ///
+    /// Une lettre minuscule.
+    fn is_lowercase_letter(self) -> bool;
+
+    /// Lettre majuscule
+    ///
+    /// Une lettre majuscule.
+    fn is_uppercase_letter(self) -> bool;
+
+    /// Saut de ligne.
+    ///
+    /// Note: U+000D CARRIAGE RETURN et U+000C FORM FEED ne sont pas inclus
+    /// dans cette définition, car ils sont convertis en U+000A LINE FEED
+    /// lors du prétraitement.
+    fn is_newline(self) -> bool;
+}
+
+// -------------- //
+// Implémentation // -> Interface
+// -------------- //
+
+impl CSSCodePoint for CodePoint {
+    fn is_css_digit(self) -> bool {
+        self.is_ascii_digit()
+    }
+
+    fn is_css_whitespace(self) -> bool {
+        self.is_newline() || matches!(self, '\t' | ' ')
+    }
+
+    fn is_ident_codepoint(self) -> bool {
+        self.is_ident_start_codepoint()
+            || self.is_css_digit()
+            || self == '-'
+    }
+
+    fn is_ident_start_codepoint(self) -> bool {
+        self.is_letter()
+    }
+
+    fn is_letter(self) -> bool {
+        self.is_lowercase_letter() || self.is_uppercase_letter()
+    }
+
+    fn is_lowercase_letter(self) -> bool {
+        self.is_ascii_lowercase()
+    }
+
+    fn is_uppercase_letter(self) -> bool {
+        self.is_ascii_uppercase()
+    }
+
+    fn is_newline(self) -> bool {
+        self == '\n'
+    }
+}

--- a/css/parser/lib.rs
+++ b/css/parser/lib.rs
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+mod codepoint;
+
+/// 4. Tokenization
+mod tokenization;
+
+use infra::primitive::codepoint::CodePoint;
+
+use self::tokenization::CSSTokenizer;
+
+// --------- //
+// Structure //
+// --------- //
+
+pub struct CSSParser<C> {
+    tokenizer: CSSTokenizer<C>,
+}
+
+// -------------- //
+// Implémentation //
+// -------------- //
+
+impl<C> CSSParser<C>
+where
+    C: Iterator<Item = CodePoint>,
+{
+    pub fn new(input: C) -> Self {
+        Self {
+            tokenizer: CSSTokenizer::new(input),
+        }
+    }
+}

--- a/css/parser/tokenization/mod.rs
+++ b/css/parser/tokenization/mod.rs
@@ -1,0 +1,8 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+mod token;
+mod tokenizer;
+
+pub use self::{token::CSSToken, tokenizer::CSSTokenizer};

--- a/css/parser/tokenization/token.rs
+++ b/css/parser/tokenization/token.rs
@@ -2,6 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+// --------- //
+// Structure //
+// --------- //
+
+use infra::primitive::codepoint::CodePoint;
+
+#[derive(Debug)]
+#[derive(Default)]
+#[derive(PartialEq, Eq)]
+pub struct DimensionUnit(String);
+
 // ----------- //
 // Énumération //
 // ----------- //
@@ -46,7 +57,8 @@ pub enum CSSToken {
 
     /// Les `<dimension-token>` ont en outre une unité composée d'un ou
     /// plusieurs points de code.
-    Dimension(f64, NumberFlag, String),
+    Dimension(f64, NumberFlag, DimensionUnit),
+
     Whitespace,
 
     /// Suite de points de code "<!--"
@@ -61,17 +73,17 @@ pub enum CSSToken {
     /// Caractère ','
     Comma,
     /// Caractère '['
-    LeftBracket,
+    LeftSquareBracket,
     /// Caractère ']'
-    RightBracket,
+    RightSquareBracket,
     /// Caractère '('
     LeftParenthesis,
     /// Caractère ')'
     RightParenthesis,
     /// Caractère '{'
-    LeftBrace,
+    LeftCurlyBracket,
     /// Caractère '}'
-    RightBrace,
+    RightCurlyBracket,
 
     EOF,
 }
@@ -98,9 +110,34 @@ pub enum NumberFlag {
     Number,
 }
 
+// -------------- //
+// Implémentation //
+// -------------- //
+
+impl CSSToken {
+    pub(crate) fn append_character(&mut self, ch: CodePoint) {
+        match self {
+            | Self::Ident(s)
+            | Self::Function(s)
+            | Self::AtKeyword(s)
+            | Self::Hash(s, _)
+            | Self::Url(s)
+            | Self::String(s) => s.push(ch),
+            | _ => (),
+        }
+    }
+}
+
+impl DimensionUnit {
+    pub fn new(unit: String) -> Self {
+        Self(unit)
+    }
+}
 
 // -------------- //
 // Implémentation // -> Interface
 // -------------- //
 
+// NOTE(phisyx): obligé de faire ceci à cause du type f64 dans notre
+//               énumération.
 impl Eq for CSSToken {}

--- a/css/parser/tokenization/token.rs
+++ b/css/parser/tokenization/token.rs
@@ -1,0 +1,106 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// ----------- //
+// Énumération //
+// ----------- //
+
+#[derive(Debug)]
+#[derive(PartialEq)]
+pub enum CSSToken {
+    /// `<ident-token>`, `<function-token>`, `<at-keyword-token>`,
+    /// <hash-token>`, `<string-token>` et `<url-token>` ont une valeur
+    /// composée de zéro ou plus points de code.
+    ///
+    /// Identifiant (comme auto`, `disc`, etc., qui sont simplement écrit
+    /// comme leur valeur).
+    Ident(String),
+
+    /// Nom de la fonction suivi du caractère `(`, comme `translate(`.
+    Function(String),
+
+    /// Forme d'un caractère `@` suivi de la valeur du jeton, comme
+    /// `@media`.
+    AtKeyword(String),
+
+    /// Les jetons de hachage ont un indicateur de type défini sur "id" ou
+    /// "unrestricted" en plus.
+    Hash(String, HashFlag),
+
+    String(String),
+    BadString,
+    Url(String),
+    BadUrl,
+
+    /// `<delim-token>` a une valeur composée d'un seul point de code.
+    Delim(char),
+
+    /// `<number-token>`, `<percentage-token>` et `<dimension-token>` ont
+    /// une valeur numérique. `<number-token>` et `<dimension-token>` ont
+    /// en outre un indicateur de type défini sur "integer" ou
+    /// "number".
+    Number(f64, NumberFlag),
+
+    Percentage(f64),
+
+    /// Les `<dimension-token>` ont en outre une unité composée d'un ou
+    /// plusieurs points de code.
+    Dimension(f64, NumberFlag, String),
+    Whitespace,
+
+    /// Suite de points de code "<!--"
+    Cdo,
+    /// Suite de points de code "-->"
+    Cdc,
+
+    /// Caractère ':'
+    Colon,
+    /// Caractère ';'
+    Semicolon,
+    /// Caractère ','
+    Comma,
+    /// Caractère '['
+    LeftBracket,
+    /// Caractère ']'
+    RightBracket,
+    /// Caractère '('
+    LeftParenthesis,
+    /// Caractère ')'
+    RightParenthesis,
+    /// Caractère '{'
+    LeftBrace,
+    /// Caractère '}'
+    RightBrace,
+
+    EOF,
+}
+
+#[derive(Debug)]
+#[derive(Default)]
+#[derive(PartialEq, Eq)]
+pub enum HashFlag {
+    ID,
+
+    /// Le drapeau de type prend par défaut la valeur "unrestricted".
+    #[default]
+    Unrestricted,
+}
+
+#[derive(Debug)]
+#[derive(Default)]
+#[derive(PartialEq, Eq)]
+pub enum NumberFlag {
+    /// Le drapeau de type prend par défaut la valeur "integer".
+    #[default]
+    Integer,
+
+    Number,
+}
+
+
+// -------------- //
+// Implémentation // -> Interface
+// -------------- //
+
+impl Eq for CSSToken {}

--- a/css/parser/tokenization/tokenizer.rs
+++ b/css/parser/tokenization/tokenizer.rs
@@ -1,0 +1,59 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::borrow::Cow;
+
+use infra::primitive::codepoint::CodePoint;
+use parser::preprocessor::InputStream;
+
+use super::CSSToken;
+use crate::{codepoint::CSSCodePoint, tokenization::token::HashFlag};
+
+// ---- //
+// Type //
+// ---- //
+
+pub(crate) type CSSInputStream<Iter> = InputStream<Iter, CodePoint>;
+
+// --------- //
+// Structure //
+// --------- //
+
+/// Pour tokeniser un flux de points de code en un flux de jetons CSS en
+/// entrée, nous devons consommer de manière répétée un jeton en entrée
+/// jusqu'à ce qu'un <EOF-token> soit atteint, en poussant chacun des
+/// jetons retournés dans un flux.
+pub struct CSSTokenizer<Chars> {
+    pub(crate) stream: CSSInputStream<Chars>,
+}
+
+// -------------- //
+// Implémentation //
+// -------------- //
+
+impl<C> CSSTokenizer<C>
+where
+    C: Iterator<Item = CodePoint>,
+{
+    /// Crée un nouveau [tokenizer](CSSTokenizer) à partir d'un flux de
+    /// points de code.
+    pub fn new(iter: C) -> Self {
+        // Remplacer tous les points de code
+        //   - U+000D CARRIAGE RETURN (CR),
+        //   - U+000C FORM FEED (FF)
+        //   - U+000D CARRIAGE RETURN (CR) suivis de U+000A LINE FEED (LF)
+        // par un seul point de code U+000A LINE FEED (LF).
+        //
+        // Remplacer tout point de code U+0000 NULL ou de substitution en
+        // entrée par U+FFFD REPLACEMENT CHARACTER (�).
+        let stream =
+            CSSInputStream::new(iter).with_pre_scan(|ch| match ch {
+                | Some('\r' | '\n' | '\x0C') => Some('\n'),
+                | Some('\0') => Some(CodePoint::REPLACEMENT_CHARACTER),
+                | n => n,
+            });
+
+        Self { stream }
+    }
+}

--- a/css/parser/tokenization/tokenizer.rs
+++ b/css/parser/tokenization/tokenizer.rs
@@ -103,10 +103,8 @@ where
             if let Some('(') = self.stream.next_input_character() {
                 self.stream.advance(1);
 
-                self.stream.advance_as_long_as(
-                    |ch| ch.is_css_whitespace(),
-                    Some(2),
-                );
+                self.stream
+                    .advance_as_long_as(|ch| ch.is_css_whitespace(), 2);
 
                 if let Some(v) =
                     self.stream.meanwhile().peek_until::<Vec<_>>(2)
@@ -628,7 +626,7 @@ where
                 // vérifie que `ch` s' agit bien d'une valeur hexadécimale.
                 let total_hexdigits = self
                     .stream
-                    .advance_as_long_as(|ch| ch.is_ascii_digit(), Some(5))
+                    .advance_as_long_as(|ch| ch.is_ascii_digit(), 5)
                     .iter()
                     .fold(
                         ch.to_digit(HEXARADIX)

--- a/css/parser/tokenization/tokenizer.rs
+++ b/css/parser/tokenization/tokenizer.rs
@@ -2,12 +2,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::borrow::Cow;
+use std::{
+    borrow::Cow,
+    ops::{AddAssign, MulAssign},
+};
 
-use infra::primitive::codepoint::CodePoint;
+use infra::{
+    primitive::codepoint::{CodePoint, CodePointInterface},
+    structure::lists::peekable::PeekableInterface,
+};
 use parser::preprocessor::InputStream;
 
-use super::CSSToken;
+use super::{
+    token::{DimensionUnit, NumberFlag},
+    CSSToken,
+};
 use crate::{codepoint::CSSCodePoint, tokenization::token::HashFlag};
 
 // ---- //
@@ -55,5 +64,1009 @@ where
             });
 
         Self { stream }
+    }
+}
+
+impl<C> CSSTokenizer<C>
+where
+    C: Iterator<Item = CodePoint>,
+{
+    /// Voir <https://www.w3.org/TR/css-syntax-3/#consume-comment>
+    fn consume_comments(&mut self) {
+        'f: loop {
+            let start = self.stream.next_n_input_character(2);
+
+            if start != "/*" {
+                break 'f;
+            }
+
+            self.stream.advance(2);
+
+            's: loop {
+                let last = self.stream.next_n_input_character(2);
+
+                if last == "*/" {
+                    self.stream.advance(2);
+                    break 's;
+                } else {
+                    self.stream.advance(1);
+                }
+            }
+        }
+    }
+
+    /// Voir <https://www.w3.org/TR/css-syntax-3/#consume-an-ident-like-token>
+    fn consume_ident_like_token(&mut self) -> Option<CSSToken> {
+        let result = self.consume_ident_sequence();
+
+        if result.eq_ignore_ascii_case("url") {
+            if let Some('(') = self.stream.next_input_character() {
+                self.stream.advance(1);
+
+                self.stream.advance_as_long_as(
+                    |ch| ch.is_css_whitespace(),
+                    Some(2),
+                );
+
+                if let Some(v) =
+                    self.stream.meanwhile().peek_until::<Vec<_>>(2)
+                {
+                    let cond0 = v[0] == '\'' || v[0] == '"';
+                    let cond1 = v[1] == '\'' || v[1] == '"';
+                    let cond2 = v[0] == ' ' && cond1;
+
+                    if cond0 && cond1 || cond2 {
+                        return Some(CSSToken::Function(result));
+                    }
+                }
+
+                return self.consume_url_token();
+            }
+        }
+
+        if let Some('(') = self.stream.next_input_character() {
+            self.stream.advance(1);
+            return Some(CSSToken::Function(result));
+        }
+
+        Some(CSSToken::Ident(result))
+    }
+
+    /// Voir <https://www.w3.org/TR/css-syntax-3/#consume-number>
+    //
+    // NOTE(phisyx): `type` est un mot clé réservé de Rust.
+    //               C'est pour cela qu'on ne respecte pas vraiment la
+    //               nomenclature de la présente spécification dans le
+    //               cas présent.
+    fn consume_number(&mut self) -> Option<(f64, NumberFlag)> {
+        let mut flag = NumberFlag::Integer;
+        // ---- ^^^^ : voir la NOTE ci-haut.
+        let mut repr = String::new();
+
+        if let Some(ch @ ('+' | '-')) = self.stream.next_input_character()
+        {
+            repr.push(ch);
+            self.stream.advance(1);
+        }
+
+        let digits = self
+            .stream
+            .advance_as_long_as(|next_ch| next_ch.is_css_digit(), None);
+        repr.extend(&digits);
+
+        if let Some(v) = self.stream.meanwhile().peek_until::<Vec<_>>(2) {
+            if v[0] == '.' && v[1].is_css_digit() {
+                self.stream.advance(2);
+                repr.extend(&v);
+                flag = NumberFlag::Number;
+                repr.extend(&self.stream.advance_as_long_as(
+                    |next_ch| next_ch.is_css_digit(),
+                    None,
+                ));
+            }
+        }
+
+        if let Some(v) = self.stream.meanwhile().peek_until::<Vec<_>>(3) {
+            let is_minus_or_plus = v[1] == '-' || v[1] == '+';
+            if v[0].to_ascii_lowercase() == 'e'
+                && (is_minus_or_plus && v[2].is_css_digit())
+                || v[1].is_css_digit()
+            {
+                let offset = if is_minus_or_plus { 3 } else { 2 };
+                self.stream.advance(offset);
+                repr.extend(&v[..offset]);
+                flag = NumberFlag::Number;
+                repr.extend(&self.stream.advance_as_long_as(
+                    |next_ch| next_ch.is_css_digit(),
+                    None,
+                ));
+            }
+        }
+
+        let value = convert_string_to_number(repr);
+        value.map(|v| (v, flag))
+    }
+
+    /// Voir <https://www.w3.org/TR/css-syntax-3/#consume-numeric-token>
+    fn consume_numeric_token(&mut self) -> Option<CSSToken> {
+        let (number, number_flag) =
+            self.consume_number().expect("Nombre attendu");
+
+        if check_3_codepoints_would_start_an_ident_sequence(
+            self.stream.next_n_input_character(3),
+        ) {
+            return Some(CSSToken::Dimension(
+                number,
+                number_flag,
+                DimensionUnit::new(self.consume_ident_sequence()),
+            ));
+        }
+
+        if let Some('%') = self.stream.next_input_character() {
+            self.stream.advance(1);
+            return Some(CSSToken::Percentage(number));
+        }
+
+        Some(CSSToken::Number(number, number_flag))
+    }
+
+    fn consume_string_token(
+        &mut self,
+        ending_codepoint: CodePoint,
+    ) -> Option<CSSToken> {
+        let mut string = String::new();
+
+        loop {
+            match self.stream.consume_next_input_character() {
+                // ending code point
+                //
+                // Retourner un <string-token>.
+                | Some(ch) if ch == ending_codepoint => break,
+
+                // EOF
+                //
+                // Il s'agit d'une erreur d'analyse. Retourner un
+                // <string-token>.
+                | None => {
+                    // TODO(phisyx): gérer l'erreur.
+                    break;
+                }
+
+                // newline
+                //
+                // Il s'agit d'une erreur d'analyse. Re-consommer le
+                // point de code d'entrée actuel, créer un
+                // <bad-string-token> et le retourner.
+                | Some(ch) if ch.is_newline() => {
+                    // TODO(phisyx): gérer l'erreur.
+                    self.stream.rollback();
+                    return Some(CSSToken::BadString);
+                }
+
+                // U+005C REVERSE SOLIDUS (\)
+                //
+                // Si le prochain point de code d'entrée est EOF, ne rien
+                // faire.
+                // Sinon, si le prochain point de code d'entrée est une
+                // nouvelle ligne, nous devons le consommer.
+                // Sinon, (le flux commence par un échappement valide)
+                // consommer un point de code échappé et ajouter le point
+                // de code renvoyé à la valeur de <string-token>.
+                | Some('\\') => {
+                    match self.stream.next_input_character() {
+                        | Some(ch) if ch.is_newline() => {
+                            self.stream.advance(1);
+                        }
+                        | _ => {}
+                    };
+
+                    if check_2_codepoints_are_a_valid_escape(
+                        self.stream.next_n_input_character(2),
+                    ) {
+                        self.stream.advance(2);
+                        string.push_str("\\\\");
+                    }
+                }
+
+                // Anything else
+                //
+                // Ajouter le point de code d'entrée actuel à la valeur de
+                // <string-token>.
+                | _ => string
+                    .push(self.stream.current.expect("Caractère courant")),
+            }
+        }
+
+        Some(CSSToken::String(string))
+    }
+
+    /// Voir <https://www.w3.org/TR/css-syntax-3/#consume-token>
+    fn consume_token(&mut self) -> Option<CSSToken> {
+        // Consume comments.
+        self.consume_comments();
+
+        // Consume the next input code point.
+        match self.stream.consume_next_input_character() {
+            // whitespace
+            //
+            // Consomme autant d'espace blanc que possible. Retourne un
+            // <whitespace-token>.
+            | Some(ch) if ch.is_css_whitespace() => {
+                self.stream.advance_as_long_as(
+                    |next_ch| next_ch.is_css_whitespace(),
+                    None,
+                );
+                Some(CSSToken::Whitespace)
+            }
+
+            // U+0022 QUOTATION MARK (")
+            // U+0027 APOSTROPHE (')
+            //
+            // Consomme un jeton de chaîne et le renvoie.
+            | Some(ch @ ('"' | '\'')) => self.consume_string_token(ch),
+
+            // U+0023 NUMBER SIGN (#)
+            //
+            // Si le point de code d'entrée suivant est un point de code
+            // ident ou si les deux points de code d'entrée suivants sont
+            // un échappement valide, alors nous devons:
+            //   1. Créer un <hash-token>.
+            //   2. Si les 3 points de code d'entrée suivants commencent
+            // une par une séquence ident, nous devons définir un drapeau
+            // de type <hash-token> sur "id".
+            //   3. Consommer une séquence ident, et définir la valeur du
+            // <hash-token> à la chaîne retournée.
+            //   4. Retourner le <hash-token>.
+            //
+            // Sinon, retourner un <delim-token> avec sa valeur définie sur
+            // le point de code d'entrée actuel.
+            | Some('#') => {
+                fn then<C>(
+                    tokenizer: &mut CSSTokenizer<C>,
+                ) -> Option<CSSToken>
+                where
+                    C: Iterator<Item = CodePoint>,
+                {
+                    let mut flag = Default::default();
+                    let mut hash = String::new();
+
+                    if check_3_codepoints_would_start_an_ident_sequence(
+                        tokenizer.stream.next_n_input_character(3),
+                    ) {
+                        flag = HashFlag::ID;
+                    }
+
+                    hash.push_str(&tokenizer.consume_ident_sequence());
+
+                    CSSToken::Hash(hash, flag).into()
+                }
+
+                if let Some(ch) = self.stream.next_input_character() {
+                    if ch.is_ident_codepoint() {
+                        return then(self);
+                    }
+                }
+
+                if check_2_codepoints_are_a_valid_escape(
+                    self.stream.next_n_input_character(2),
+                ) {
+                    return then(self);
+                }
+
+                self.stream.current.map(CSSToken::Delim)
+            }
+
+            // U+0028 LEFT PARENTHESIS (()
+            //
+            // Consomme un jeton de type <(-token>.
+            | Some('(') => Some(CSSToken::LeftParenthesis),
+
+            // U+0029 RIGHT PARENTHESIS ())
+            //
+            // Retourne un <)-token>.
+            | Some(')') => Some(CSSToken::RightParenthesis),
+
+            // U+002B PLUS SIGN (+)
+            //
+            // Si le flux d'entrée commence par un nombre, nous devons
+            // reprendre le point de code d'entrée actuel, consommer un
+            // jeton numérique et le retourner.
+            | Some('+')
+                if check_3_codepoints_would_start_a_number(
+                    self.stream.next_n_input_character(3),
+                ) =>
+            {
+                self.stream.rollback();
+                self.consume_numeric_token()
+            }
+
+            // U+002B PLUS SIGN (+)
+            //
+            // Retourner un <delim-token> dont la valeur est fixée
+            // au point de code d'entrée actuel.
+            | Some('+') => self.stream.current.map(CSSToken::Delim),
+
+            // U+002C COMMA (,)
+            //
+            // Retourner un <comma-token>.
+            | Some(',') => Some(CSSToken::Comma),
+
+            // U+002D HYPHEN-MINUS (-)
+            //
+            // Si le flux d'entrée commence par un nombre, nous devons
+            // re-consommer le point de code d'entrée actuel, consommer un
+            // jeton numérique et le retourner.
+            | Some('-')
+                if check_3_codepoints_would_start_a_number(
+                    self.stream.next_n_input_character(3),
+                ) =>
+            {
+                self.stream.rollback();
+                self.consume_numeric_token()
+            }
+
+            // U+002D HYPHEN-MINUS (-)
+            //
+            // Si les 2 prochains points de code d'entrée sont U+002D
+            // HYPHEN-MINUS U+003E GREATER-THAN SIGN (->), les consommer et
+            // retourner un <CDC-token>.
+            | Some('-') if self.stream.next_n_input_character(2) == "->" =>
+            {
+                self.stream.advance(2);
+                Some(CSSToken::Cdc)
+            }
+
+            // U+002D HYPHEN-MINUS (-)
+            //
+            // si le flux d'entrée commence par une séquence ident,
+            // re-consommer le point de code d'entrée actuel, consommer un
+            // jeton de type ident, et le retourner.
+            | Some('-')
+                if check_3_codepoints_would_start_an_ident_sequence(
+                    self.stream.next_n_input_character(3),
+                ) =>
+            {
+                self.stream.rollback();
+                self.consume_ident_like_token()
+            }
+
+            // U+002D HYPHEN-MINUS (-)
+            //
+            // Retourner un <delim-token> dont la valeur est fixée au
+            // point de code d'entrée actuel.
+            | Some('-') => self.stream.current.map(CSSToken::Delim),
+
+            // U+002E FULL STOP (.)
+            //
+            // Si le flux d'entrée commence par un nombre, nous devons
+            // re-consommer le point de code d'entrée actuel, consommer un
+            // jeton numérique et le retourner.
+            | Some('.')
+                if check_3_codepoints_would_start_a_number(
+                    self.stream.next_n_input_character(3),
+                ) =>
+            {
+                self.stream.rollback();
+                self.consume_numeric_token()
+            }
+
+            // U+002E FULL STOP (.)
+            //
+            // Retourner un <delim-token> dont la valeur est fixée au
+            // point de code d'entrée actuel.
+            | Some('.') => self.stream.current.map(CSSToken::Delim),
+
+            // U+003A COLON (:)
+            //
+            // Retourner un <colon-token>.
+            | Some(':') => Some(CSSToken::Colon),
+
+            // U+003B SEMICOLON (;)
+            //
+            // Retourner un <semicolon-token>.
+            | Some(';') => Some(CSSToken::Semicolon),
+
+            // U+003C LESS-THAN SIGN (<)
+            //
+            // Si les 3 points de code d'entrée suivants sont U+0021
+            // EXCLAMATION MARK U+002D HYPHEN-MINUS U+002D HYPHEN-MINUS
+            // (!--), les consommer et retourner un <CDO-token>.
+            | Some('<')
+                if self.stream.next_n_input_character(3) == "!--" =>
+            {
+                self.stream.advance(3);
+                Some(CSSToken::Cdo)
+            }
+
+            // U+003C LESS-THAN SIGN (<)
+            //
+            // Retourner un <delim-token> dont la valeur est fixée au
+            // point de code d'entrée actuel.
+            | Some('<') => self.stream.current.map(CSSToken::Delim),
+
+            // U+0040 COMMERCIAL AT (@)
+            //
+            // Si les 3 points de code d'entrée qui suivent démarrent une
+            // séquence d'identification, consommer une séquence
+            // d'identification, créer un <at-keyword-token> avec sa
+            // valeur définie sur la valeur renvoyée, et le retourner.
+            | Some('@')
+                if check_3_codepoints_would_start_an_ident_sequence(
+                    self.stream.next_n_input_character(3),
+                ) =>
+            {
+                self.stream.rollback();
+                CSSToken::AtKeyword(self.consume_ident_sequence()).into()
+            }
+
+            // U+0040 COMMERCIAL AT (@)
+            //
+            // Retourner un <delim-token> dont la valeur est fixée au
+            // point de code d'entrée actuel.
+            | Some('@') => self.stream.current.map(CSSToken::Delim),
+
+            // U+005B LEFT SQUARE BRACKET ([)
+            //
+            // Retourner un <[-token>.
+            | Some('[') => Some(CSSToken::LeftSquareBracket),
+
+            // U+005C REVERSE SOLIDUS (\)
+            //
+            // Si le flux d'entrée commence par un échappement valide, nous
+            // devons re-consommer le point de code d'entrée actuel,
+            // consommer un jeton de type ident-like, et le retourner.
+            | Some('\\')
+                if check_3_codepoints_would_start_an_ident_sequence(
+                    self.stream.next_n_input_character(3),
+                ) =>
+            {
+                self.stream.rollback();
+                self.consume_ident_like_token()
+            }
+
+            // U+005C REVERSE SOLIDUS (\)
+            //
+            // Retourner un <delim-token> dont la valeur est fixée au
+            // point de code d'entrée actuel.
+            | Some('\\') => self.stream.current.map(CSSToken::Delim),
+
+            // U+005D RIGHT SQUARE BRACKET (])
+            //
+            // Retourner un <]-token>.
+            | Some(']') => Some(CSSToken::RightSquareBracket),
+
+            // U+007B LEFT CURLY BRACKET ({)
+            //
+            // Retourner un <{-token>.
+            | Some('{') => Some(CSSToken::LeftCurlyBracket),
+
+            // U+007D RIGHT CURLY BRACKET (})
+            //
+            // Retourner un <}-token>.
+            | Some('}') => Some(CSSToken::RightCurlyBracket),
+
+            // digit
+            //
+            // Re-consommer le point de code d'entrée actuel, consommer un
+            // jeton numérique et le retourner.
+            | Some(ch) if ch.is_css_digit() => {
+                self.stream.rollback();
+                self.consume_numeric_token()
+            }
+
+            // ident-start code point
+            //
+            // Re-consommer le point de code d'entrée actuel, consommer un
+            // jeton de type ident-like, et le retourner.
+            | Some(ch) if ch.is_ident_start_codepoint() => {
+                self.stream.rollback();
+                self.consume_ident_like_token()
+            }
+
+            // EOF
+            //
+            // Retourner un <EOF-token>.
+            | None => Some(CSSToken::EOF),
+
+            // Anything else
+            | _ => self.stream.current.map(CSSToken::Delim),
+        }
+    }
+
+    /// Voir <https://www.w3.org/TR/css-syntax-3/#consume-name>
+    fn consume_ident_sequence(&mut self) -> String {
+        let mut result = String::new();
+
+        loop {
+            if let Some(next_ch) = self.stream.consume_next_input() {
+                if next_ch.is_ident_codepoint() {
+                    result.push(next_ch);
+                    continue;
+                }
+
+                if let Some(next_peek_ch) =
+                    self.stream.next_input_character()
+                {
+                    if check_2_codepoints_are_a_valid_escape(format!(
+                        "{next_ch}{next_peek_ch}"
+                    )) {
+                        result.push(self.consume_escaped_codepoint());
+                        continue;
+                    }
+                }
+
+                self.stream.rollback();
+            }
+
+            break;
+        }
+
+        result
+    }
+
+    /// Voir <https://www.w3.org/TR/css-syntax-3/#consume-escaped-code-point>
+    fn consume_escaped_codepoint(&mut self) -> CodePoint {
+        match self.stream.consume_next_input_character() {
+            // hex digit
+            //
+            // Consommer autant de chiffres hexadécimaux que possible, mais
+            // pas plus de 5.
+            // NOTE(css): cela signifie que 1 à 6 chiffres hexadécimaux ont
+            // été consommés au total.
+            // Si le prochain point de code d'entrée est un espace blanc,
+            // nous devons le consommer. Interpréter les chiffres
+            // hexadécimaux comme un nombre hexadécimal. Si ce nombre est
+            // zéro, ou s'il s'agit d'un substitut, ou s'il est supérieur
+            // au point de code maximum autorisé, retourner U+FFFD
+            // REPLACEMENT CHARACTER (�). Sinon, retourner le point de code
+            // avec cette valeur.
+            | Some(ch) if ch.is_ascii_hexdigit() => {
+                const HEXARADIX: u32 = 16;
+
+                // NOTE(phisyx): nous pouvons utiliser .expect() ici, sans
+                // que ce soit problématique, car la condition ci-dessus
+                // vérifie que `ch` s' agit bien d'une valeur hexadécimale.
+                let total_hexdigits = self
+                    .stream
+                    .advance_as_long_as(|ch| ch.is_ascii_digit(), Some(5))
+                    .iter()
+                    .fold(
+                        ch.to_digit(HEXARADIX)
+                            .expect("Voir la note ci-dessus"),
+                        |mut total, ch| {
+                            total.mul_assign(HEXARADIX);
+                            total.add_assign(
+                                ch.to_digit(HEXARADIX)
+                                    .expect("Voir la note ci-dessus"),
+                            );
+                            total
+                        },
+                    );
+
+                let next_peek_ch = self.stream.next_input_character();
+                if let Some('\n') = next_peek_ch {
+                    self.stream.advance(1);
+                }
+
+                let hexnumber = CodePoint::from_u32(total_hexdigits)
+                    .unwrap_or(CodePoint::REPLACEMENT_CHARACTER);
+
+                // NOTE(phisyx): n'a peut-être pas le comportement attendue
+                // par la spécification ; à tester.
+                if hexnumber == '\0'
+                    || hexnumber.is_surrogate()
+                    || hexnumber.is_gt_maximum_allowed_codepoint()
+                {
+                    CodePoint::REPLACEMENT_CHARACTER
+                } else {
+                    hexnumber
+                }
+            }
+
+            // EOF
+            //
+            // Il s'agit d'une erreur d'analyse. Retourner U+FFFD
+            // REPLACEMENT CHARACTER (�).
+            // TODO(phisyx): gérer cette erreur d'analyse.
+            | None => CodePoint::REPLACEMENT_CHARACTER,
+
+            // Anything else
+            //
+            // Retourner le point de code d'entrée actuel.
+            | _ => self.stream.current.expect(
+                "Le caractère courant, qui a forcément déjà été assigné.",
+            ),
+        }
+    }
+
+    /// Voir <https://www.w3.org/TR/css-syntax-3/#consume-remnants-of-bad-url>
+    fn consume_remnants_of_bad_url(&mut self) {
+        loop {
+            match self.stream.consume_next_input() {
+                // U+0029 RIGHT PARENTHESIS ())
+                // EOF
+                //
+                // Retourner.
+                | Some(')') | None => break,
+
+                // Anything else
+                | Some(ch) => {
+                    // the input stream starts with a valid escape
+                    //
+                    // Consommer un point de code échappé.
+                    // NOTE(css): cela permet de rencontrer une parenthèse
+                    // droite échappée ("\)") sans terminer le
+                    // <bad-url-token>. Cette clause est par ailleurs
+                    // identique à la clause "anything else".
+                    if let Some(next_peek_ch) =
+                        self.stream.next_input_character()
+                    {
+                        if check_2_codepoints_are_a_valid_escape(format!(
+                            "{ch}{next_peek_ch}"
+                        )) {
+                            self.consume_escaped_codepoint();
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Voir <https://www.w3.org/TR/css-syntax-3/#consume-url-token>
+    fn consume_url_token(&mut self) -> Option<CSSToken> {
+        self.stream.advance_as_long_as(
+            |next_ch| next_ch.is_css_whitespace(),
+            None,
+        );
+
+        let mut url_token = CSSToken::Url(String::default());
+
+        loop {
+            match self.stream.consume_next_input() {
+                // U+0029 RIGHT PARENTHESIS ())
+                //
+                // Retourner un <url-token>.
+                | Some(')') => break,
+
+                // EOF
+                | None => break,
+
+                // whitespace
+                //
+                // Consommer autant d'espace blanc que possible. Si le
+                // prochain point de code d'entrée est U+0029 RIGHT
+                // PARENTHESIS ()) ou EOF, nous devons le consommer et
+                // retourner le <url-token> (si EOF a été rencontré, c'est
+                // une erreur d'analyse) ; sinon, nous devons consommer les
+                // restes d'une mauvaise url, créer un <bad-url-token>, et
+                // le retourner.
+                | Some(ch) if ch.is_css_whitespace() => {
+                    self.stream.advance_as_long_as(
+                        |next_ch| next_ch.is_css_whitespace(),
+                        None,
+                    );
+
+                    if let next_peek_ch @ (Some(')') | None) =
+                        self.stream.next_input_character()
+                    {
+                        self.stream.advance(1);
+
+                        if next_peek_ch.is_none() { // eof
+                             // TODO(phisyx): gérer les erreurs.
+                        }
+
+                        break;
+                    }
+
+                    self.consume_remnants_of_bad_url();
+                    return Some(CSSToken::BadUrl);
+                }
+
+                // U+0022 QUOTATION MARK (")
+                // U+0027 APOSTROPHE (')
+                // U+0028 LEFT PARENTHESIS (()
+                //
+                // Il s'agit d'une erreur d'analyse. Consommer les
+                // restes d'une mauvaise url, créer un <bad-url-token>,
+                // et le retourner.
+                | Some('"' | '\'' | '(') => {
+                    self.consume_remnants_of_bad_url();
+                    return Some(CSSToken::BadUrl);
+                }
+                // non-printable code point
+                //
+                // Il s'agit d'une erreur d'analyse. Consommer les
+                // restes d'une mauvaise url, créer un <bad-url-token>,
+                // et le retourner.
+                | Some(ch) if ch.is_non_printable_codepoint() => {
+                    self.consume_remnants_of_bad_url();
+                    return Some(CSSToken::BadUrl);
+                }
+
+                // U+005C REVERSE SOLIDUS (\)
+                //
+                // Si le flux commence par un échappement valide, nous
+                // devons consommer un point de code échappé et ajoute le
+                // point de code renvoyé à la valeur de <url-token>.
+                //
+                // Sinon, il s'agit d'une erreur d'analyse. Consomme les
+                // restes d'une mauvaise url, crée un <bad-url-token>, et
+                // le renvoie.
+                | Some(ch @ '\\') => {
+                    if let Some(next_peek_ch) =
+                        self.stream.next_input_character()
+                    {
+                        if check_2_codepoints_are_a_valid_escape(format!(
+                            "{ch}{next_peek_ch}",
+                        )) {
+                            url_token.append_character(
+                                self.consume_escaped_codepoint(),
+                            );
+                        } else {
+                            // TODO(phisyx): gérer les erreurs.
+                            self.consume_remnants_of_bad_url();
+                            return Some(CSSToken::BadUrl);
+                        }
+                    }
+                }
+
+                // Anything else
+                //
+                // Ajouter le point de code d'entrée actuel à la valeur de
+                // <url-token>.
+                | Some(ch) => url_token.append_character(ch),
+            }
+        }
+
+        Some(url_token)
+    }
+}
+
+/// Vérifie si trois points de code permettent de lancer une séquence
+/// ident.
+fn check_3_codepoints_would_start_an_ident_sequence(
+    maybe_ident_sequence: Cow<str>,
+) -> bool {
+    let mut chars = maybe_ident_sequence.chars();
+
+    let first_codepoint = chars.next();
+    match first_codepoint {
+        // U+002D HYPHEN-MINUS
+        //
+        // Si le deuxième point de code est un point de code de début
+        // ident ou un HYPHEN-MINUS U+002D, ou si le deuxième et
+        // troisième points de code sont des échappements valides,
+        // nous devons alors retourner true. Sinon false.
+        | Some('-') => {
+            let second_codepoint = chars.next();
+            match second_codepoint {
+                | Some(ch) if ch.is_ident_start_codepoint() => true,
+                | Some('-') => true,
+                | Some('\\') => {
+                    let third_codepoint = chars.next();
+                    match third_codepoint {
+                        | Some('\\') => true,
+                        | _ => false,
+                    }
+                }
+                | _ => false,
+            }
+        }
+
+        // ident-start code point
+        | Some(ch) if ch.is_ident_start_codepoint() => true,
+
+        // U+005C REVERSE SOLIDUS (\)
+        //
+        // Si le premier et le second point de code sont des
+        // échappements valides, nous devons retourner
+        // true. Sinon false.
+        | Some('\\') => {
+            let second_codepoint = chars.next();
+            match second_codepoint {
+                | Some('\\') => true,
+                | _ => false,
+            }
+        }
+
+        // Anything else
+        //
+        // Retourner false.
+        | _ => false,
+    }
+}
+
+/// Vérifier si trois points de code permettent de commencer un numéro
+fn check_3_codepoints_would_start_a_number(
+    maybe_number: Cow<str>,
+) -> bool {
+    let mut chars = maybe_number.chars();
+
+    let first_codepoint = chars.next();
+    match first_codepoint {
+        // U+002B PLUS SIGN (+)
+        // U+002D HYPHEN-MINUS (-)
+        //
+        // Si le deuxième point de code est un chiffre, nous devons
+        // retourner true.
+        // Sinon, si le deuxième point de code est un U+002E FULL STOP (.)
+        // et le troisième point de code est un chiffre, nous devons
+        // retourner true.
+        // Sinon false.
+        | Some('+' | '-') => {
+            let second_codepoint = chars.next();
+            match second_codepoint {
+                | Some(ch) if ch.is_css_digit() => true,
+                | Some('.') => {
+                    let third_codepoint = chars.next();
+                    match third_codepoint {
+                        | Some(ch) if ch.is_css_digit() => true,
+                        | _ => false,
+                    }
+                }
+                | _ => false,
+            }
+        }
+
+        // U+002E FULL STOP (.)
+        //
+        // Si le deuxième point de code est un chifre, nous devons
+        // retourner true. Sinon false.
+        | Some('.') => {
+            let second_codepoint = chars.next();
+            match second_codepoint {
+                | Some(ch) if ch.is_css_digit() => true,
+                | _ => false,
+            }
+        }
+
+        // digit
+        | Some(ch) if ch.is_css_digit() => true,
+
+        // Anything else
+        | _ => false,
+    }
+}
+
+/// Vérifie si deux points de code constituent un échappement valide.
+fn check_2_codepoints_are_a_valid_escape(
+    maybe_valid_escape: impl AsRef<str>,
+) -> bool {
+    let mut chars = maybe_valid_escape.as_ref().chars();
+
+    let first_codepoint = chars.next();
+    if first_codepoint != Some('\\') {
+        return false;
+    }
+
+    let second_codepoint = chars.next();
+    if second_codepoint == Some('\n') {
+        return false;
+    }
+
+    true
+}
+
+/// Voir <https://www.w3.org/TR/css-syntax-3/#convert-string-to-number>
+/// Le langage Rust implémente déjà cela.
+fn convert_string_to_number(s: String) -> Option<f64> {
+    s.parse().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tokenization::token::HashFlag;
+
+    macro_rules! load_fixture {
+        ($filename:literal) => {{
+            let css_file = include_str!($filename);
+            CSSTokenizer::new(css_file.chars())
+        }};
+    }
+
+    macro_rules! test_the_str {
+        ($str:literal) => {{
+            let s = $str;
+            CSSTokenizer::new(s.chars())
+        }};
+    }
+
+    #[test]
+    fn test_consume_comments() {
+        let mut tokenizer = test_the_str!(
+            "/* comment 1 */\r\n#id { color: red }/* comment 2 */"
+        );
+
+        // NOTE(phisyx): tester si le premier jeton n'est pas '/'
+        //               actuellement le script retourne None.
+        assert_eq!(tokenizer.consume_token(), Some(CSSToken::Whitespace));
+    }
+
+    #[test]
+    fn test_consume_token_quotation_mark() {
+        let mut tokenizer = test_the_str!("'hello world'");
+        assert_eq!(
+            tokenizer.consume_token(),
+            Some(CSSToken::String("hello world".into()))
+        );
+
+        let mut tokenizer = test_the_str!(r#""foo bar""#);
+        assert_eq!(
+            tokenizer.consume_token(),
+            Some(CSSToken::String("foo bar".into()))
+        );
+
+        let mut tokenizer = test_the_str!(r#""foo'bar""#);
+        assert_eq!(
+            tokenizer.consume_token(),
+            Some(CSSToken::String("foo'bar".into()))
+        );
+
+        let mut tokenizer = test_the_str!(r#""foo"bar""#);
+        assert_eq!(
+            tokenizer.consume_token(),
+            Some(CSSToken::String("foo".into()))
+        );
+
+        let mut tokenizer = test_the_str!("\"bad\nstring\"");
+        assert_eq!(tokenizer.consume_token(), Some(CSSToken::BadString));
+    }
+
+    #[test]
+    fn test_consume_token_number_sign() {
+        let mut tokenizer = test_the_str!("#id { color: #000 }");
+
+        assert_eq!(
+            tokenizer.consume_token(),
+            Some(CSSToken::Hash("id".into(), HashFlag::ID))
+        );
+
+        let mut tokenizer = test_the_str!("#id\\:2 {color: red; }");
+
+        assert_eq!(
+            tokenizer.consume_token(),
+            Some(CSSToken::Hash("id:2".into(), HashFlag::ID))
+        );
+
+        // TODO(phisyx): tester les couleurs de ce test.
+    }
+
+    #[test]
+    fn test_consume_ident_like() {
+        let mut tokenizer =
+            test_the_str!("#id { background: url(img.png); }");
+
+        for _ in 0..7 {
+            tokenizer.consume_token();
+        }
+
+        assert_eq!(
+            tokenizer.consume_token(),
+            Some(CSSToken::Url("img.png".into()))
+        );
+
+        let mut tokenizer =
+            test_the_str!("#id { transform: translateX(0deg); }");
+
+        for _ in 0..7 {
+            tokenizer.consume_token();
+        }
+
+        assert_eq!(
+            tokenizer.consume_token(),
+            Some(CSSToken::Function("translateX".into()))
+        );
+
+        let mut tokenizer = test_the_str!("#id { color: red; }");
+
+        for _ in 0..7 {
+            tokenizer.consume_token();
+        }
+
+        assert_eq!(
+            tokenizer.consume_token(),
+            Some(CSSToken::Ident("red".into()))
+        );
     }
 }

--- a/dom/node/document.rs
+++ b/dom/node/document.rs
@@ -67,7 +67,6 @@ impl Document {
         }
     }
 
-    /// todo: FIXME
     pub fn create_element(
         local_name: impl AsRef<str>,
         options: Option<CreateElementOptions>,

--- a/dom/node/element.rs
+++ b/dom/node/element.rs
@@ -23,7 +23,7 @@ use super::{document_fragment::DocumentFragmentNode, DocumentNode};
 #[derive(Debug)]
 pub struct Element {
     inner: HTMLElement,
-    // todo: changer en NamedNodeMap (cf. https://dom.spec.whatwg.org/#namednodemap)
+    // TODO(phisyx): changer le type de cet attribut en NamedNodeMap (cf. https://dom.spec.whatwg.org/#namednodemap)
     pub attributes: RwLock<HashMap<DOMString, DOMString>>,
     pub id: RwLock<Option<DOMString>>,
     pub is: RwLock<Option<DOMString>>,

--- a/dom/node/mod.rs
+++ b/dom/node/mod.rs
@@ -147,7 +147,8 @@ impl Node {
     }
 
     /// Retourne la donnée du noeud, qui est l'élément courant.
-    // FIXME: au lieux de panic comme un demeuré: mieux gérer les erreurs.
+    // NOTE(phisyx): au lieux de panic comme un demeuré: mieux gérer les
+    // erreurs.
     pub fn element_ref(&self) -> &Element {
         match self.node_data.as_ref() {
             | Some(NodeData::Element(element)) => element,
@@ -156,7 +157,8 @@ impl Node {
     }
 
     /// Retourne la donnée du noeud, qui est le document courant.
-    // FIXME: au lieux de panic comme un demeuré: mieux gérer les erreurs.
+    // NOTE(phisyx): au lieux de panic comme un demeuré: mieux gérer les
+    // erreurs.
     pub fn document_ref(&self) -> &Document {
         match self.node_data.as_ref() {
             | Some(NodeData::Document(ref d)) => d,
@@ -165,7 +167,8 @@ impl Node {
     }
 
     /// Retourne la donnée du noeud, qui est l'élément script.
-    // FIXME: au lieux de panic comme un demeuré: mieux gérer les erreurs.
+    // NOTE(phisyx): au lieux de panic comme un demeuré: mieux gérer les
+    // erreurs.
     pub fn script_ref(&self) -> &HTMLScriptElement<DocumentNode> {
         match self.node_data.as_ref() {
             | Some(NodeData::Element(element)) => element.script(),
@@ -175,7 +178,8 @@ impl Node {
 
     /// Défini une suite de caractères au noeud courant dans lequel nous
     /// pouvons définir des [données de caractères](CharacterData).
-    // FIXME: au lieux de panic comme un demeuré: mieux gérer les erreurs.
+    // NOTE(phisyx): au lieux de panic comme un demeuré: mieux gérer les
+    // erreurs.
     pub fn set_data(&self, data: &str) {
         match self.node_data.as_ref() {
             | Some(NodeData::CharacterData(cd)) => cd.set_data(data),

--- a/html/parser/Cargo.toml
+++ b/html/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-html-parser"
-version = "1.1.142"
+version = "1.1.143"
 license-file = "../../LICENSE"
 edition = "2021"
 

--- a/html/parser/error.rs
+++ b/html/parser/error.rs
@@ -146,10 +146,10 @@ define_errors! {
     /// à l'intérieur du contenu d'un élément de script (par exemple,
     /// `<script><!-- foo`).
     ///
-    /// Note: les structures syntaxiques qui ressemblent à des commentaires
-    /// HTML dans les éléments de script sont analysées comme du contenu
-    /// textuel. Elles peuvent faire partie d'une structure syntaxique
-    /// spécifique au langage de script ou être traitées comme un
+    /// NOTE(html): les structures syntaxiques qui ressemblent à des
+    /// commentaires HTML dans les éléments de script sont analysées comme
+    /// du contenu textuel. Elles peuvent faire partie d'une structure
+    /// syntaxique spécifique au langage de script ou être traitées comme un
     /// commentaire de type HTML, si le langage de script les prend en
     /// charge (par exemple, les règles d'analyse des commentaires de type
     /// HTML se trouvent à l'annexe B de la spécification JavaScript). La
@@ -171,8 +171,8 @@ define_errors! {
     /// présent) ou jusqu'à la fin du flux d'entrée est traité comme un
     /// commentaire.
     ///
-    /// Note: une cause possible de cette erreur est l'utilisation d'une
-    /// déclaration de balisage XML (par exemple, `<!ELEMENT br EMPTY>`)
+    /// NOTE(html): une cause possible de cette erreur est l'utilisation
+    /// d'une déclaration de balisage XML (par exemple, `<!ELEMENT br EMPTY>`)
     /// dans l'HTML.
     IncorrectlyOpenedComment = "incorrectly-opened-comment",
 
@@ -210,7 +210,7 @@ define_errors! {
     ///         |- #text: <42>
     ///         |- #comment: 42
     ///
-    /// Note: alors que le premier point de code d'un nom de balise est
+    /// NOTE(html): alors que le premier point de code d'un nom de balise est
     /// limité à un alpha ASCII, un large éventail de points de code (y
     /// compris des chiffres ASCII) est autorisé dans les positions
     /// suivantes.
@@ -340,7 +340,7 @@ define_errors! {
     /// d'attribut. L'analyseur syntaxique inclut ces points de code dans
     /// le nom de l'attribut.
     ///
-    /// Note: les points de code qui déclenchent cette erreur font
+    /// NOTE(html): les points de code qui déclenchent cette erreur font
     /// généralement partie d'une autre construction syntaxique et peuvent
     /// être le signe d'une faute de frappe autour du nom de l'attribut.
     ///
@@ -361,12 +361,12 @@ define_errors! {
     /// U+0060 (`) dans une valeur d'attribut (unquoted). L'analyseur
     /// syntaxique inclut ces points de code dans la valeur de l'attribut.
     ///
-    /// Note 1: les points de code qui déclenchent cette erreur font
+    /// NOTE(html) 1: les points de code qui déclenchent cette erreur font
     /// généralement partie d'une autre construction syntaxique et peuvent
     /// être le signe d'une faute de frappe autour de la valeur de
     /// l'attribut.
     ///
-    /// Note 2: U+0060 (`) figure dans la liste des points de code qui
+    /// NOTE(html) 2: U+0060 (`) figure dans la liste des points de code qui
     /// déclenchent cette erreur parce que certains agents utilisateurs
     /// anciens le traitent comme un guillemet.
     ///
@@ -380,7 +380,7 @@ define_errors! {
     /// l'analyseur syntaxique traite U+003D (=) comme le premier point de
     /// code du nom de l'attribut.
     ///
-    /// Note: la raison courante de cette erreur est un nom d'attribut
+    /// NOTE(html): la raison courante de cette erreur est un nom d'attribut
     /// oublié.
     ///
     /// Example: `<div foo="bar" ="baz">`
@@ -413,8 +413,8 @@ define_errors! {
     ///      | - head
     ///      | - body
     ///
-    /// Note: la raison courante de cette erreur est une instruction de
-    /// traitement XML (par exemple, `<?xml-stylesheet type="text/css"
+    /// NOTE(html): la raison courante de cette erreur est une instruction
+    /// de traitement XML (par exemple, `<?xml-stylesheet type="text/css"
     /// href="style.css"?>`) ou une déclaration XML (par exemple, `<?xml
     /// version="1.0" encoding="UTF-8"?>`) utilisée dans HTML.
     UnexpectedQuestionMarkInsteadOfTagName = "unexpected-question-mark-instead-of-tag-name",

--- a/html/parser/error.rs
+++ b/html/parser/error.rs
@@ -441,14 +441,15 @@ define_errors! {
 mod tests {
     use dom::node::DocumentNode;
     use infra::primitive::codepoint::CodePoint;
-    use parser::preprocessor::InputStream;
 
-    use crate::tokenization::{HTMLToken, HTMLTokenizer};
+    use crate::tokenization::{
+        tokenizer::HTMLInputStream, HTMLToken, HTMLTokenizer,
+    };
 
     fn get_tokenizer_html(
         input: &'static str,
     ) -> HTMLTokenizer<impl Iterator<Item = CodePoint>> {
-        let stream = InputStream::new(input.chars());
+        let stream = HTMLInputStream::new(input.chars());
         HTMLTokenizer::new(DocumentNode::default(), stream)
     }
 

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -71,7 +71,7 @@ where
         loop {
             let token = self.tokenizer.next_token();
 
-            // todo: améliorer cette partie-ci.
+            // TODO(phisyx): à améliorer ASAP.
             match self.tokenizer.tree_construction.dispatcher(token) {
                 | ControlFlow::Continue(HTMLParserState::SwitchTo(
                     state,
@@ -95,7 +95,7 @@ where
                     }
                 }
 
-                // todo(fixme): à améliorer asap.
+                // TODO(phisyx): à améliorer ASAP.
                 | ControlFlow::Continue(HTMLParserState::CustomRcdata) => {
                     if let Some(HTMLToken::Character('\n')) =
                         self.tokenizer.next_token()
@@ -125,8 +125,8 @@ where
                     continue;
                 }
 
-                | ControlFlow::Break(HTMLParserFlag::Pause) => break, /* todo */
-                | ControlFlow::Break(HTMLParserFlag::Stop) => break, /* todo */
+                | ControlFlow::Break(HTMLParserFlag::Pause) => break, /* Voir TODO ci-haut */
+                | ControlFlow::Break(HTMLParserFlag::Stop) => break, /* Voir TODO ci-haut */
             }
         }
     }

--- a/html/parser/tokenization/state/cdata.rs
+++ b/html/parser/tokenization/state/cdata.rs
@@ -18,7 +18,7 @@ where
     pub(crate) fn handle_cdata_section_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // U+005D RIGHT SQUARE BRACKET (])
             //
             // Passer à l'état `cdata-section-bracket`.
@@ -46,7 +46,7 @@ where
     pub(crate) fn handle_cdata_section_bracket_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // U+005D RIGHT SQUARE BRACKET (])
             //
             // Passer à l'état `cdata-section-end`.
@@ -68,7 +68,7 @@ where
     pub(crate) fn handle_cdata_section_end_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // U+005D RIGHT SQUARE BRACKET (])
             //
             // Émettre un jeton `character` U+005D RIGHT SQUARE BRACKET.

--- a/html/parser/tokenization/state/character_reference.rs
+++ b/html/parser/tokenization/state/character_reference.rs
@@ -24,7 +24,7 @@ where
         self.set_temporary_buffer(String::new())
             .append_character_to_temporary_buffer('&');
 
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // ASCII alphanumeric
             //
             // Reprendre dans l'état `named-character-reference`.
@@ -135,7 +135,7 @@ where
     pub(crate) fn handle_ambiguous_ampersand_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // ASCII alphanumeric
             //
             // Si la référence de caractère a été consommée dans le cadre
@@ -179,7 +179,7 @@ where
         // Définir le code de référence du caractère à zéro (0).
         self.character_reference_code = 0;
 
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // U+0078 LATIN SMALL LETTER X
             // U+0058 LATIN CAPITAL LETTER X
             //
@@ -200,7 +200,7 @@ where
     pub(crate) fn handle_hexadecimal_character_reference_start_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // ASCII hex digit
             //
             // Reprendre dans l'état `hexadecimal-character-reference`.
@@ -226,7 +226,7 @@ where
     pub(crate) fn handle_decimal_character_reference_start_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // ASCII digit
             //
             // Reprendre dans l'état `decimal-character-reference`.
@@ -252,7 +252,7 @@ where
     pub(crate) fn handle_hexadecimal_character_reference_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // ASCII digit
             //
             // Multiplier le code de référence du caractère par 16. Ajouter
@@ -319,7 +319,7 @@ where
     pub(crate) fn handle_decimal_character_reference_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // ASCII digit
             //
             // Multiplier le code de référence du caractère par 10. Ajouter

--- a/html/parser/tokenization/state/comment.rs
+++ b/html/parser/tokenization/state/comment.rs
@@ -21,7 +21,7 @@ where
     pub(crate) fn handle_bogus_comment_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // U+003E GREATER-THAN SIGN (>)
             //
             // Passer à l'état `data`. Émettre le jeton `comment` actuel.
@@ -128,7 +128,7 @@ where
     pub(crate) fn handle_comment_start_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // U+002D HYPHEN-MINUS (-)
             //
             // Passer à l'état `comment-start-dash`.
@@ -155,7 +155,7 @@ where
     pub(crate) fn handle_comment_less_than_sign_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // U+0021 EXCLAMATION MARK (!)
             //
             // Ajouter le caractère actuel aux données du jeton `comment`.
@@ -186,7 +186,7 @@ where
     pub(crate) fn handle_comment_less_than_sign_bang_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // U+002D HYPHEN-MINUS (-)
             //
             // Passer à l'état `comment-less-than-sign-bang-dash`.
@@ -204,7 +204,7 @@ where
     pub(crate) fn handle_comment_less_than_sign_bang_dash_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // U+002D HYPHEN-MINUS (-)
             //
             // Passer à l'état `comment-less-than-sign-bang-dash-dash`.
@@ -222,7 +222,7 @@ where
     pub(crate) fn handle_comment_less_than_sign_bang_dash_dash_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // U+003E GREATER-THAN SIGN (>)
             // EOF
             //
@@ -244,7 +244,7 @@ where
     pub(crate) fn handle_comment_start_dash_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // U+002D HYPHEN-MINUS (-)
             //
             // Passer à l'état final du commentaire.
@@ -287,7 +287,7 @@ where
     pub(crate) fn handle_comment_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // U+003C LESS-THAN SIGN (<)
             //
             // Ajouter le caractère actuel aux données du jeton `comment`.
@@ -342,7 +342,7 @@ where
     pub(crate) fn handle_comment_end_dash_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // U+002D HYPHEN-MINUS (-)
             //
             // Passer à l'état `comment-end`.
@@ -376,7 +376,7 @@ where
     pub(crate) fn handle_comment_end_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // U+003E GREATER-THAN SIGN (>)
             //
             // Passer à l'état `data`. Émettre le jeton `comment` actuel.
@@ -426,7 +426,7 @@ where
     pub(crate) fn handle_comment_end_bang_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // U+002D HYPHEN-MINUS (-)
             //
             // Ajouter deux caractères U+002D HYPHEN-MINUS (-) et un

--- a/html/parser/tokenization/state/data.rs
+++ b/html/parser/tokenization/state/data.rs
@@ -19,7 +19,7 @@ where
     pub(crate) fn handle_data_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // U+0026 AMPERSAND (&)
             //
             // Définir l'état de retour à l'état `data`. Passer à l'état

--- a/html/parser/tokenization/state/doctype.rs
+++ b/html/parser/tokenization/state/doctype.rs
@@ -25,7 +25,7 @@ where
     pub(crate) fn handle_doctype_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // U+0009 CHARACTER TABULATION (tab)
             // U+000A LINE FEED (LF)
             // U+000C FORM FEED (FF)
@@ -68,7 +68,7 @@ where
     pub(crate) fn handle_before_doctype_name_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // U+0009 CHARACTER TABULATION (tab)
             // U+000A LINE FEED (LF)
             // U+000C FORM FEED (FF)
@@ -141,7 +141,7 @@ where
     pub(crate) fn handle_doctype_name_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // U+0009 CHARACTER TABULATION (tab)
             // U+000A LINE FEED (LF)
             // U+000C FORM FEED (FF)
@@ -209,7 +209,7 @@ where
     pub(crate) fn handle_after_doctype_name_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // U+0009 CHARACTER TABULATION (tab)
             // U+000A LINE FEED (LF)
             // U+000C FORM FEED (FF)
@@ -299,7 +299,7 @@ where
     pub(crate) fn handle_after_doctype_public_keyword_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // U+0009 CHARACTER TABULATION (tab)
             // U+000A LINE FEED (LF)
             // U+000C FORM FEED (FF)
@@ -389,7 +389,7 @@ where
     pub(crate) fn handle_before_doctype_public_identifier_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // U+0009 CHARACTER TABULATION (tab)
             // U+000A LINE FEED (LF)
             // U+000C FORM FEED (FF)
@@ -466,7 +466,7 @@ where
         &mut self,
         quote: CodePoint,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // U+0022 QUOTATION MARK (")
             //
             // Passer à l'état `after-doctype-public-identifier`.
@@ -537,7 +537,7 @@ where
     pub(crate) fn handle_after_doctype_public_identifier_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // U+0009 CHARACTER TABULATION (tab)
             // U+000A LINE FEED (LF)
             // U+000C FORM FEED (FF)
@@ -609,7 +609,7 @@ where
     pub(crate) fn handle_between_doctype_public_and_system_identifiers_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // U+0009 CHARACTER TABULATION (tab)
             // U+000A LINE FEED (LF)
             // U+000C FORM FEED (FF)
@@ -675,7 +675,7 @@ where
     pub(crate) fn handle_after_doctype_system_keyword_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // U+0009 CHARACTER TABULATION (tab)
             // U+000A LINE FEED (LF)
             // U+000C FORM FEED (FF)
@@ -766,7 +766,7 @@ where
     pub(crate) fn handle_before_doctype_system_identifier_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // U+0009 CHARACTER TABULATION (tab)
             // U+000A LINE FEED (LF)
             // U+000C FORM FEED (FF)
@@ -847,7 +847,7 @@ where
         &mut self,
         quote: CodePoint,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // U+0022 QUOTATION MARK (")
             // U+0027 APOSTROPHE (')
             //
@@ -913,7 +913,7 @@ where
     pub(crate) fn handle_after_doctype_system_identifier_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // U+0009 CHARACTER TABULATION (tab)
             // U+000A LINE FEED (LF)
             // U+000C FORM FEED (FF)
@@ -958,7 +958,7 @@ where
     pub(crate) fn handle_bogus_doctype_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // U+003E GREATER-THAN SIGN (>)
             //
             // Passer à l'état `data`. Émettre le jeton `doctype`.

--- a/html/parser/tokenization/state/plaintext.rs
+++ b/html/parser/tokenization/state/plaintext.rs
@@ -18,7 +18,7 @@ where
     pub(crate) fn handle_plaintext_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // U+0000 NULL
             //
             // Il s'agit d'une erreur d'analyse de type

--- a/html/parser/tokenization/state/rawtext.rs
+++ b/html/parser/tokenization/state/rawtext.rs
@@ -21,7 +21,7 @@ where
     pub(crate) fn handle_rawtext_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // U+003C LESS-THAN SIGN (<)
             //
             // Passer à l'état `rawtext-less-than-sign`.
@@ -57,7 +57,7 @@ where
     pub(crate) fn handle_rawtext_less_than_sign_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // U+002F SOLIDUS (/)
             //
             // Définir le tampon temporaire à une chaîne de caractères
@@ -81,7 +81,7 @@ where
     pub(crate) fn handle_rawtext_end_tag_open_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // ASCII alpha
             //
             // Créer un nouveau jeton `end-tag`, définir son nom de
@@ -108,7 +108,7 @@ where
     pub(crate) fn handle_rawtext_end_tag_name_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // U+0009 CHARACTER TABULATION (tab)
             // U+000A LINE FEED (LF)
             // U+000C FORM FEED (FF)

--- a/html/parser/tokenization/state/rcdata.rs
+++ b/html/parser/tokenization/state/rcdata.rs
@@ -21,7 +21,7 @@ where
     pub(crate) fn handle_rcdata_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // U+0026 AMPERSAND (&)
             //
             // Définir l'état de retour à l'état `rcdata`. Passer à l'état
@@ -66,7 +66,7 @@ where
     pub(crate) fn handle_rcdata_less_than_sign_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // U+002F SOLIDUS (/)
             //
             // Définir le tampon temporaire à une chaîne de caractères
@@ -91,7 +91,7 @@ where
     pub(crate) fn handle_rcdata_end_tag_open_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // ASCII alpha
             //
             // Créer un nouveau jeton `end-tag`, définir son nom comme une
@@ -118,7 +118,7 @@ where
     pub(crate) fn handle_rcdata_end_tag_name_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // U+0009 CHARACTER TABULATION (tab)
             // U+000A LINE FEED (LF)
             // U+000C FORM FEED (FF)

--- a/html/parser/tokenization/state/script_data.rs
+++ b/html/parser/tokenization/state/script_data.rs
@@ -21,7 +21,7 @@ where
     pub(crate) fn handle_script_data_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // U+003C LESS-THAN SIGN (<)
             //
             // Passer à l'état `script-data-less-than-sign`.
@@ -57,7 +57,7 @@ where
     pub(crate) fn handle_script_data_less_than_sign_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // U+002F SOLIDUS (/)
             //
             // Définir le tampon temporaire comme une chaîne de caractères
@@ -92,7 +92,7 @@ where
     pub(crate) fn handle_script_data_end_tag_open_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // ASCII alpha
             //
             // Créer un nouveau jeton `end-tag`, définir son nom de balise
@@ -117,7 +117,7 @@ where
     pub(crate) fn handle_script_data_end_tag_name_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // U+0009 CHARACTER TABULATION (tab)
             // U+000A LINE FEED (LF)
             // U+000C FORM FEED (FF)
@@ -197,7 +197,7 @@ where
     pub(crate) fn handle_script_data_escape_start_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // U+002D HYPHEN-MINUS (-)
             //
             // Passer à l'état `script-data-escape-start-dash`. Émettre un
@@ -217,7 +217,7 @@ where
     pub(crate) fn handle_script_data_escape_start_dash_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // U+002D HYPHEN-MINUS (-)
             //
             // Passer à l'état `script-data-escaped-dash-dash`.
@@ -237,7 +237,7 @@ where
     pub(crate) fn handle_script_data_escaped_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // U+002D HYPHEN-MINUS (-)
             //
             // Passer à l'état `script-data-escaped-dash`. Émettre un jeton
@@ -286,7 +286,7 @@ where
     pub(crate) fn handle_script_data_escaped_dash_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // U+002D HYPHEN-MINUS (-)
             //
             // Passer à l'état `script-data-escaped-dash-dash`.
@@ -339,7 +339,7 @@ where
     pub(crate) fn handle_script_data_escaped_dash_dash_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // U+002D HYPHEN-MINUS (-)
             //
             // Émettre un jeton `character` U+002D HYPHEN-MINUS.
@@ -399,7 +399,7 @@ where
     pub(crate) fn handle_script_data_escaped_less_than_sign_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // U+002F SOLIDUS (/)
             //
             // Définir le tampon temporaire à une chaîne de caractères
@@ -434,7 +434,7 @@ where
     pub(crate) fn handle_script_data_escaped_end_tag_open_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // ASCII alpha
             //
             // Créer un nouveau jeton `end-tag`, définir son nom de balise
@@ -461,7 +461,7 @@ where
     pub(crate) fn handle_script_data_escaped_end_tag_name_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // U+0009 CHARACTER TABULATION (tab)
             // U+000A LINE FEED (LF)
             // U+000C FORM FEED (FF)
@@ -542,7 +542,7 @@ where
     pub(crate) fn handle_script_data_double_escape_start_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // U+0009 CHARACTER TABULATION (tab)
             // U+000A LINE FEED (LF)
             // U+000C FORM FEED (FF)
@@ -602,7 +602,7 @@ where
     pub(crate) fn handle_script_data_double_escaped_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // U+002D HYPHEN-MINUS (-)
             //
             // Passer à l'état `script-data-double-escaped-dash`. Émettre
@@ -655,7 +655,7 @@ where
     pub(crate) fn handle_script_data_double_escaped_dash_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // U+002D HYPHEN-MINUS (-)
             //
             // Passer à l'état `script-data-double-escaped-dash-dash`.
@@ -712,7 +712,7 @@ where
     pub(crate) fn handle_script_data_double_escaped_dash_dash_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // U+002D HYPHEN-MINUS (-)
             //
             // Émettre un jeton `character` U+002D HYPHEN-MINUS.
@@ -776,7 +776,7 @@ where
     pub(crate) fn handle_script_data_double_escaped_less_than_sign_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // U+002F SOLIDUS (/)
             //
             // Définir le tampon temporaire à une chaîne de caractères
@@ -800,7 +800,7 @@ where
     pub(crate) fn handle_script_data_double_escape_end_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // U+0009 CHARACTER TABULATION (tab)
             // U+000A LINE FEED (LF)
             // U+000C FORM FEED (FF)

--- a/html/parser/tokenization/state/tag.rs
+++ b/html/parser/tokenization/state/tag.rs
@@ -21,7 +21,7 @@ where
     pub(crate) fn handle_tag_open_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // U+0021 EXCLAMATION MARK (!)
             //
             // Passer à l'état `markup-declaration-open`.
@@ -87,7 +87,7 @@ where
     pub(crate) fn handle_end_tag_open_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // ASCII alpha
             //
             // Créer un nouveau jeton `end tag`, et lui définir son nom
@@ -135,7 +135,7 @@ where
     pub(crate) fn handle_tag_name_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // U+0009 CHARACTER TABULATION (tab)
             // U+000A LINE FEED (LF)
             // U+000C FORM FEED (FF)
@@ -208,7 +208,7 @@ where
     pub(crate) fn handle_before_attribute_name_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // U+0009 CHARACTER TABULATION (tab)
             // U+000A LINE FEED (LF)
             // U+000C FORM FEED (FF)
@@ -262,7 +262,7 @@ where
     pub(crate) fn handle_attribute_name_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // U+0009 CHARACTER TABULATION (tab)
             // U+000A LINE FEED (LF)
             // U+000C FORM FEED (FF)
@@ -343,7 +343,7 @@ where
     pub(crate) fn handle_after_attribute_name_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // U+0009 CHARACTER TABULATION (tab)
             // U+000A LINE FEED (LF)
             // U+000C FORM FEED (FF)
@@ -397,7 +397,7 @@ where
     pub(crate) fn handle_before_attribute_value_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // U+0009 CHARACTER TABULATION (tab)
             // U+000A LINE FEED (LF)
             // U+000C FORM FEED (FF)
@@ -442,7 +442,7 @@ where
         &mut self,
         quote: CodePoint,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // U+0022 QUOTATION MARK (")
             //
             // Passer à l'état `after-attribute-value-quoted`.
@@ -511,7 +511,7 @@ where
     pub(crate) fn handle_attribute_value_unquoted_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // U+0009 CHARACTER TABULATION (tab)
             // U+000A LINE FEED (LF)
             // U+000C FORM FEED (FF)
@@ -595,7 +595,7 @@ where
     pub(crate) fn handle_after_attribute_value_quoted_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // U+0009 CHARACTER TABULATION (tab)
             // U+000A LINE FEED (LF)
             // U+000C FORM FEED (FF)
@@ -642,7 +642,7 @@ where
     pub(crate) fn handle_self_closing_start_tag_state(
         &mut self,
     ) -> HTMLTokenizerProcessResult {
-        match self.stream.next_input_char() {
+        match self.stream.consume_next_input_character() {
             // U+003E GREATER-THAN SIGN (>)
             //
             // Définir le drapeau `self-closing` au jeton `tag` actuel sur

--- a/html/parser/tokenization/tokenizer.rs
+++ b/html/parser/tokenization/tokenizer.rs
@@ -67,11 +67,7 @@ pub(crate) type HTMLTokenizerProcessResult = Result<
 // Structure //
 // --------- //
 
-#[derive(Debug)]
-pub struct HTMLTokenizer<Chars>
-where
-    Chars: Iterator<Item = CodePoint>,
-{
+pub struct HTMLTokenizer<Chars> {
     pub(crate) stream: HTMLInputStream<Chars>,
     pub(crate) tree_construction: HTMLTreeConstruction,
 

--- a/html/parser/tree_construction/mod.rs
+++ b/html/parser/tree_construction/mod.rs
@@ -439,7 +439,9 @@ impl HTMLTreeConstruction {
                 }
             }
 
-            | _ => todo!(),
+            // NOTE(phisyx): la spécification n'indique pas de traitement
+            //               pour les autres types de jetons.
+            | _ => unreachable!(),
         };
 
         HTMLTreeConstructionControlFlow::Continue(
@@ -699,8 +701,8 @@ impl HTMLTreeConstruction {
     ///    2.1. Si le `foster parenting` est activée et que la cible est
     /// un élément table, tbody, tfoot, thead ou tr.
     ///
-    ///    Note: Le `foster parenting` se produit lorsque le contenu est
-    /// mal intégré dans les table's.
+    ///    NOTE(html): Le `foster parenting` se produit lorsque le contenu
+    /// est mal intégré dans les table's.
     ///
     ///      2.1.1. Le dernier template est le dernier élément template
     /// dans la pile d'éléments ouverts, s'il y en a.
@@ -734,11 +736,11 @@ impl HTMLTreeConstruction {
     /// l'intérieur de l'élément précédent, après son dernier enfant (le
     /// cas échéant).
     ///
-    ///    Note: Ces étapes sont nécessaires en partie parce qu'il est
-    /// possible que des éléments, en particulier l'élément table dans ce
-    /// cas, aient été déplacés par un script dans le DOM, ou même
-    /// entièrement retirés du DOM, après que l'élément ait été inséré par
-    /// l'analyseur.
+    ///    NOTE(html): Ces étapes sont nécessaires en partie parce qu'il
+    /// est possible que des éléments, en particulier l'élément table
+    /// dans ce cas, aient été déplacés par un script dans le DOM, ou
+    /// même entièrement retirés du DOM, après que l'élément ait été
+    /// inséré par l'analyseur.
     ///
     ///    2.2. Sinon : l'emplacement d'insertion ajusté doit être à
     /// l'intérieur de la cible, après son dernier enfant (s'il y en a).
@@ -1131,7 +1133,7 @@ impl HTMLTreeConstruction {
     /// ont été ouverts dans le body, cell ou caption courant (selon le
     /// plus jeune) et qui n'ont pas été explicitement fermés.
     ///
-    /// Note: La liste des éléments de formatage actifs est toujours
+    /// NOTE(html): La liste des éléments de formatage actifs est toujours
     /// constituée d'éléments dans l'ordre chronologique, l'élément le
     /// moins récemment ajouté étant le premier et l'élément le plus
     /// récemment ajouté le dernier (sauf pendant l'exécution des étapes 7
@@ -1163,7 +1165,8 @@ impl HTMLTreeConstruction {
             return;
         };
 
-        // todo: probablement à améliorer.
+        // NOTE(phisyx): code qui est à propice à des bugs; à améliorer et
+        //               à tester.
         #[allow(unused_labels)]
         'main: loop {
             // Rewind

--- a/html/parser/tree_construction/rules/body.rs
+++ b/html/parser/tree_construction/rules/body.rs
@@ -999,10 +999,11 @@ impl HTMLTreeConstruction {
             // Insérer un élément HTML pour le jeton.
             // Passer le tokenizer à l'état PLAINTEXT.
             //
-            // Note: Une fois qu'une balise de début avec le nom de balise
-            // "plaintext" a été vue, ce sera le dernier jeton vu autre que
-            // les jetons de caractères (et le jeton de fin de fichier),
-            // car il n'y a aucun moyen de sortir de l'état PLAINTEXT.
+            // NOTE(html): Une fois qu'une balise de début avec le nom de
+            // balise "plaintext" a été vue, ce sera le dernier jeton vu
+            // autre que les jetons de caractères (et le jeton de fin de
+            // fichier), car il n'y a aucun moyen de sortir de l'état
+            // PLAINTEXT.
             #[allow(deprecated)]
             | HTMLToken::Tag {
                 ref name,
@@ -1808,7 +1809,7 @@ impl HTMLTreeConstruction {
                 ..
             } if tag_names::textarea == name => {
                 self.insert_html_element(token.as_tag());
-                // todo(fixme): améliorer cette partie ci.
+                // TODO(phisyx): améliorer cette partie ci.
                 return HTMLTreeConstructionControlFlow::Continue(
                     HTMLParserState::CustomRcdata,
                 );
@@ -1997,8 +1998,8 @@ impl HTMLTreeConstruction {
                 self.insert_html_element(token.as_tag());
             }
 
-            // todo: A start tag whose tag name is one of: "math"
-            // todo: A start tag whose tag name is one of: "svg"
+            // TODO(html): A start tag whose tag name is one of: "math"
+            // TODO(html): A start tag whose tag name is one of: "svg"
 
             // A start tag whose tag name is one of: "caption", "col",
             // "colgroup", "frame", "head", "tbody", "td", "tfoot", "th",
@@ -2034,7 +2035,7 @@ impl HTMLTreeConstruction {
             // a.
             // Insérer un élément HTML pour le jeton.
             //
-            // Note: Cet élément sera un élément ordinaire.
+            // NOTE(html): Cet élément sera un élément ordinaire.
             | HTMLToken::Tag { is_end: false, .. } => {
                 self.reconstruct_active_formatting_elements();
                 self.insert_html_element(token.as_tag());

--- a/html/parser/tree_construction/rules/frameset.rs
+++ b/html/parser/tree_construction/rules/frameset.rs
@@ -143,8 +143,8 @@ impl HTMLTreeConstruction {
             //
             // Si le nœud actuel n'est pas l'élément html racine, il s'agit
             // d'une erreur d'analyse.
-            // Note: Le nœud actuel ne peut être que l'élément html racine
-            // dans le cas d'un fragment.
+            // NOTE(html): Le nœud actuel ne peut être que l'élément html
+            // racine dans le cas d'un fragment.
             // Arrêter l'analyse.
             | HTMLToken::EOF => {
                 if let Some(cnode) = self.current_node() {

--- a/html/parser/tree_construction/rules/head.rs
+++ b/html/parser/tree_construction/rules/head.rs
@@ -196,7 +196,7 @@ impl HTMLTreeConstruction {
             // Accuser réception du drapeau d'auto-fermeture du jeton, s'il
             // est activé.
             //
-            // TODO:
+            // TODO(html):
             // Si l'analyseur HTML spéculatif actif est nul, alors :
             //
             //   1. Si l'élément possède un attribut charset, et que
@@ -214,9 +214,10 @@ impl HTMLTreeConstruction {
             // confiance est actuellement provisoire, alors nous devons
             // changer l'encodage pour l'encodage extrait.
             //
-            // Note: L'analyseur HTML spéculatif n'applique pas de manière
-            // spéculative les déclarations de codage des caractères afin
-            // de réduire la complexité de l'implémentation.
+            // NOTE(html): L'analyseur HTML spéculatif n'applique pas de
+            // manière spéculative les déclarations de codage des
+            // caractères afin de réduire la complexité de
+            // l'implémentation.
             | HTMLToken::Tag {
                 ref name,
                 is_end: false,
@@ -318,12 +319,12 @@ impl HTMLTreeConstruction {
                     script_element.set_already_started(true);
                 }
 
-                // todo(document.write/ln): Si l'analyseur syntaxique a été
-                // invoqué par l'intermédiaire des méthodes
-                // document.write() ou document.writeln(), il est possible
-                // de marquer l'élément script comme "déjà lancé". (Par
-                // exemple, l'agent utilisateur peut utiliser cette clause
-                // pour empêcher l'exécution de scripts d'origine croisée
+                // TODO(html): Si l'analyseur syntaxique a été invoqué
+                // par l'intermédiaire des méthodes `document.write()` ou
+                // `document.writeln()`, il est possible de marquer
+                // l'élément script comme "déjà lancé". (Par exemple,
+                // l'agent utilisateur peut utiliser cette clause pour
+                // empêcher l'exécution de scripts d'origine croisée
                 // insérés via document.write() dans des conditions de
                 // réseau lent, ou lorsque le chargement de la page a déjà
                 // pris beaucoup de temps).
@@ -690,8 +691,8 @@ impl HTMLTreeConstruction {
             // de la pile des éléments ouverts. (Il se peut que ce ne soit
             // pas le nœud actuel à ce stade).
             //
-            // Note: le pointeur de l'élément de tête ne peut pas être nul
-            // à ce stade.
+            // NOTE(html): le pointeur de l'élément de tête ne peut pas
+            // être nul à ce stade.
             #[allow(deprecated)]
             | HTMLToken::Tag {
                 ref name,

--- a/html/parser/tree_construction/rules/initial.rs
+++ b/html/parser/tree_construction/rules/initial.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 
 impl HTMLTreeConstruction {
-    // TODO: si le document n'est pas un document iframe srcdoc
+    // TODO(html): si le document n'est pas un document iframe srcdoc
     pub(crate) fn handle_initial_insertion_mode(
         &mut self,
         token: HTMLToken,
@@ -56,9 +56,9 @@ impl HTMLTreeConstruction {
             // le [HTMLToken::DOCTYPE], ou la chaîne de caractères vide si
             // l'identifiant système est manquant.
             //
-            // Note: cela garantit également que le noeud [DocumentType]
-            // est renvoyé comme valeur de l'attribut doctype de l'objet
-            // [Document].
+            // NOTE(html): cela garantit également que le noeud
+            // [DocumentType] est renvoyé comme valeur de l'attribut
+            // doctype de l'objet [Document].
             //
             // Ensuite, si le document n'est pas un document iframe srcdoc,
             // et que l'analyseur syntaxique ne peut pas changer le drapeau

--- a/html/parser/tree_construction/rules/select.rs
+++ b/html/parser/tree_construction/rules/select.rs
@@ -184,7 +184,7 @@ impl HTMLTreeConstruction {
             // ce qu'un élément select ait été retiré de la pile.
             // Réinitialiser le mode d'insertion de manière appropriée.
             //
-            // Note: Il est juste traité comme une balise de fin.
+            // NOTE(html): Il est juste traité comme une balise de fin.
             | HTMLToken::Tag {
                 ref name,
                 is_end: true,

--- a/html/parser/tree_construction/rules/text.rs
+++ b/html/parser/tree_construction/rules/text.rs
@@ -22,9 +22,9 @@ impl HTMLTreeConstruction {
             //
             // Insérer le caractère du jeton.
             //
-            // Note: il ne peut jamais s'agir d'un caractère U+0000 NULL ;
-            // le tokenizer les convertit en caractères
-            // U+FFFD REPLACEMENT CHARACTER.
+            // NOTE(html): il ne peut jamais s'agir d'un caractère U+0000
+            // NULL ; le tokenizer les convertit en caractères U+FFFD
+            // REPLACEMENT CHARACTER.
             | HTMLToken::Character(ch) => {
                 self.insert_character(ch);
             }
@@ -56,14 +56,14 @@ impl HTMLTreeConstruction {
                 );
             }
 
-            // TODO: active spéculative html tree
+            // TODO(html): active spéculative html tree
             // An end tag whose tag name is "script"
             | HTMLToken::Tag {
                 ref name,
                 is_end: true,
                 ..
             } if tag_names::script == name => {
-                todo!()
+                todo!("active spéculative html tree")
             }
 
             // Any other end tag

--- a/infra/Cargo.toml
+++ b/infra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-infra"
-version = "0.1.6"
+version = "0.1.7"
 license-file = "../LICENSE"
 edition = "2021"
 

--- a/infra/Cargo.toml
+++ b/infra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-infra"
-version = "0.1.7"
+version = "0.1.8"
 license-file = "../LICENSE"
 edition = "2021"
 

--- a/infra/algorithms/mod.rs
+++ b/infra/algorithms/mod.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-pub mod algorithms;
-pub mod namespace;
-pub mod primitive;
-pub mod structure;
+mod parameters;
+
+pub use self::parameters::{Parameter, ParameterType};

--- a/infra/algorithms/parameters.rs
+++ b/infra/algorithms/parameters.rs
@@ -98,11 +98,10 @@ macro_rules! impl_parameter_type {
 
 impl_parameter_type!(^ *mut T, *const T);
 
-impl_parameter_type!( // Copy
-    usize, u8, u16, u32, u64, u128,
-    isize, i8, i16, i32, i64, i128,
-    f32, f64,
-    bool, char
+impl_parameter_type!(
+    // Copy
+    usize, u8, u16, u32, u64, u128, isize, i8, i16, i32, i64, i128, f32,
+    f64, bool, char
 );
 
 // TODO(phisyx): ajouter une implémentation pour des types génériques.

--- a/infra/algorithms/parameters.rs
+++ b/infra/algorithms/parameters.rs
@@ -1,0 +1,129 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use core::mem;
+
+// --------- //
+// Interface //
+// --------- //
+
+pub trait ParameterType {
+    type Target;
+}
+
+pub trait Parameter<'a, T: ParameterType> {
+    fn param(self) -> CowParameter<'a, T>;
+}
+
+// ----------- //
+// Énumération //
+// ----------- //
+
+pub enum CowParameter<'a, T> {
+    Borrowed(&'a T),
+    Owned(T),
+    None,
+}
+
+// -------------- //
+// Implémentation //
+// -------------- //
+
+impl<'a, T: ParameterType> CowParameter<'a, T> {
+    /// # Safety
+    ///
+    /// Retourne une `Option<T>` qui peut être `None` si la valeur
+    /// `CowParameter` est `None`.
+    pub unsafe fn value(&self) -> Option<T> {
+        match self {
+            | Self::Borrowed(value) => Some(mem::transmute_copy(value)),
+            | Self::Owned(value) => Some(mem::transmute_copy(value)),
+            | Self::None => None,
+        }
+    }
+}
+
+// -------------- //
+// Implémentation // -> Interface
+// -------------- //
+
+impl<'a, T: ParameterType> Parameter<'a, T> for T {
+    fn param(self) -> CowParameter<'a, T> {
+        CowParameter::Owned(self)
+    }
+}
+
+impl<'a, T: ParameterType> Parameter<'a, T> for &'a T {
+    fn param(self) -> CowParameter<'a, T> {
+        CowParameter::Borrowed(self)
+    }
+}
+
+impl<'a, T: ParameterType> Parameter<'a, T> for Option<T> {
+    fn param(self) -> CowParameter<'a, T> {
+        match self {
+            | Some(value) => CowParameter::Owned(value),
+            | None => CowParameter::None,
+        }
+    }
+}
+
+impl<'a, T: ParameterType> Parameter<'a, T> for &'a Option<T> {
+    fn param(self) -> CowParameter<'a, T> {
+        match self {
+            | Some(value) => CowParameter::Borrowed(value),
+            | None => CowParameter::None,
+        }
+    }
+}
+
+impl<T> ParameterType for *mut T {
+    type Target = Self;
+}
+
+impl<T> ParameterType for *const T {
+    type Target = Self;
+}
+
+// todo: ajouter une implémentation pour des types génériques.
+// impl<T: GenericInterface> ParameterType for T {
+//     type Target = Self;
+// }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct MyStructSize {
+        height: u32,
+        width: u32,
+    }
+
+    impl ParameterType for MyStructSize {
+        type Target = Self;
+    }
+
+    fn my_fn<'a, Size: Parameter<'a, MyStructSize>>(
+        size: Size,
+    ) -> (u32, u32) {
+        let size: Option<MyStructSize> = unsafe { size.param().value() };
+        match size {
+            | Some(size) => (size.height, size.width),
+            | None => (0, 0),
+        }
+    }
+
+    #[test]
+    fn example() {
+        let struct_size = MyStructSize {
+            height: 10,
+            width: 20,
+        };
+        let size = my_fn(struct_size);
+        assert_eq!(size, (10, 20));
+
+        let size = my_fn(None);
+        assert_eq!(size, (0, 0));
+    }
+}

--- a/infra/algorithms/parameters.rs
+++ b/infra/algorithms/parameters.rs
@@ -78,15 +78,34 @@ impl<'a, T: ParameterType> Parameter<'a, T> for &'a Option<T> {
     }
 }
 
-impl<T> ParameterType for *mut T {
-    type Target = Self;
+macro_rules! impl_parameter_type {
+    ($($ty:ty),*) => {
+        $(
+            impl ParameterType for $ty {
+                type Target = Self;
+            }
+        )*
+    };
+
+    (^ $($ty:ty),*) => {
+        $(
+            impl<T> ParameterType for $ty {
+                type Target = Self;
+            }
+        )*
+    };
 }
 
-impl<T> ParameterType for *const T {
-    type Target = Self;
-}
+impl_parameter_type!(^ *mut T, *const T);
 
-// todo: ajouter une implémentation pour des types génériques.
+impl_parameter_type!( // Copy
+    usize, u8, u16, u32, u64, u128,
+    isize, i8, i16, i32, i64, i128,
+    f32, f64,
+    bool, char
+);
+
+// TODO(phisyx): ajouter une implémentation pour des types génériques.
 // impl<T: GenericInterface> ParameterType for T {
 //     type Target = Self;
 // }

--- a/infra/structure/lists/peekable.rs
+++ b/infra/structure/lists/peekable.rs
@@ -21,6 +21,12 @@ where
     /// l'itération.
     ///
     /// Le type générique est obligatoire.
+    ///
+    /// NOTE(phisyx): ce type vaut None si la position demandée est
+    /// supérieure à la longueur de l'itération, tant bien qu'il y ait
+    /// des éléments à l'intérieur du flux. Exemple: si `lookahead_offset`
+    /// vaut 5, et le flux a dans son flux `[0, 1, 2]` cela retournera
+    /// `None`.
     fn peek_until<R: FromIterator<I>>(
         &mut self,
         lookahead_offset: usize,

--- a/infra/structure/lists/queue.rs
+++ b/infra/structure/lists/queue.rs
@@ -11,12 +11,9 @@ use super::peekable::PeekableInterface;
 // --------- //
 
 #[derive(Debug)]
-pub struct ListQueue<T, I>
-where
-    T: Iterator<Item = I>,
-{
-    pub iter: T,
-    queue: Vec<Option<T::Item>>,
+pub struct ListQueue<T, I> {
+    iter: T,
+    queue: Vec<Option<I>>,
     offset: usize,
 }
 
@@ -24,10 +21,7 @@ where
 // Implémentation //
 // -------------- //
 
-impl<T, I> ListQueue<T, I>
-where
-    T: Iterator<Item = I>,
-{
+impl<T, I> ListQueue<T, I> {
     pub fn new(iter: T) -> Self {
         Self {
             iter,

--- a/infra/structure/lists/queue.rs
+++ b/infra/structure/lists/queue.rs
@@ -34,6 +34,7 @@ impl<T, I> ListQueue<T, I> {
 impl<T, I> ListQueue<T, I>
 where
     T: Iterator<Item = I>,
+    I: Clone,
 {
     fn fill_queue_max(&mut self) {
         let stored_elements = self.queue.len();
@@ -66,6 +67,12 @@ where
 
     pub fn dequeue(&mut self) -> Option<T::Item> {
         self.queue.remove(0)
+    }
+
+    // NOTE(phisyx): ceci ajoute un élément au début de la queue.
+    pub fn rollback(&mut self, last_consumed_item: Option<T::Item>) {
+        let mut temp = vec![last_consumed_item];
+        self.queue.splice(..0, temp.drain(..));
     }
 }
 
@@ -114,6 +121,7 @@ where
 impl<T, I> Iterator for ListQueue<T, I>
 where
     T: Iterator<Item = I>,
+    I: Clone,
 {
     type Item = T::Item;
 

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-parser"
-version = "0.1.7"
+version = "0.1.8"
 license-file = "../LICENSE"
 edition = "2021"
 

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-parser"
-version = "0.1.8"
+version = "0.1.10"
 license-file = "../LICENSE"
 edition = "2021"
 
@@ -9,4 +9,4 @@ path = "./lib.rs"
 
 [dependencies]
 infra = { path = "../infra", package = "resworb-infra" }
-syntax = { version = "^0.15", package = "rowan" }
+# syntax = { version = "^0.15", package = "rowan" }

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-parser"
-version = "0.1.10"
+version = "0.1.11"
 license-file = "../LICENSE"
 edition = "2021"
 

--- a/parser/decoder.rs
+++ b/parser/decoder.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use core::{fmt, str, str::Chars};
+use core::{fmt, str};
 use std::{
     fs,
     io::{self, BufReader, Read},
@@ -40,7 +40,7 @@ impl ByteStream {
     }
 
     /// Liste des caractères de la chaîne de caractères.
-    pub fn chars(&self) -> Chars {
+    pub fn chars(&self) -> str::Chars {
         self.buffer.chars()
     }
 }

--- a/parser/lib.rs
+++ b/parser/lib.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-pub use syntax;
+// pub use syntax;
 
 /// Voir <https://html.spec.whatwg.org/multipage/parsing.html#the-input-byte-stream>
 pub mod decoder;

--- a/parser/preprocessor.rs
+++ b/parser/preprocessor.rs
@@ -19,15 +19,10 @@ pub type InputStream<T, I> = InputStreamPreprocessor<T, I>;
 // Structure //
 // --------- //
 
-#[derive(Debug)]
 /// Le flux d'entrée est constitué de caractères qui y sont insérés lors
 /// du décodage du flux d'octets d'entrée ou par les diverses API qui
 /// manipulent directement le flux d'entrée.
-pub struct InputStreamPreprocessor<T, I>
-where
-    T: Iterator<Item = I>,
-    I: Clone,
-{
+pub struct InputStreamPreprocessor<T, I> {
     iter: ListQueue<T, I>,
     is_replayed: bool,
     pub current: Option<I>,
@@ -41,15 +36,12 @@ where
 impl<T, I> InputStreamPreprocessor<T, I>
 where
     T: Iterator<Item = I>,
-    I: Clone,
 {
     /// Crée un nouveau flux d'entrée.
-    pub fn new(tokenizer: T) -> Self {
-        let queue = ListQueue::new(tokenizer);
+    pub fn new(iter: T) -> Self {
+        let queue = ListQueue::new(iter);
         Self {
             iter: queue,
-            // queue: vec![],
-            // offset: 0,
             is_replayed: false,
             current: None,
             last_consumed_item: None,
@@ -85,12 +77,17 @@ where
     }
 
     /// Consomme le prochain élément du flux.
-    pub fn next_input(&mut self) -> Option<I> {
         self.next().and_then(|item| {
+    pub fn consume_next_input(&mut self) -> Option<I> {
             let some_item = Some(item);
             self.current = some_item.to_owned();
             some_item
         })
+    }
+
+    pub fn next_input(&mut self) -> Option<I> {
+        let item = self.meanwhile().peek().cloned();
+            item
     }
 }
 
@@ -101,8 +98,27 @@ where
     /// Alias de [InputStreamPreprocessor::next_input]
     ///
     /// Consomme le prochain caractère du flux.
-    pub fn next_input_char(&mut self) -> Option<Chars::Item> {
+    pub fn consume_next_input_character(&mut self) -> Option<Chars::Item> {
+        self.consume_next_input()
+    }
+
+    pub fn next_input_codepoint(&mut self) -> Option<u8> {
+        self.next_input().map(|item| item as u8)
+    }
+
+    pub fn next_input_character(&mut self) -> Option<Chars::Item> {
         self.next_input()
+    }
+
+    pub fn next_n_input_character(&mut self, offset: usize) -> Cow<str> {
+        self.slice_until(offset)
+    }
+
+    pub fn next_n_input_codepoint(&mut self, offset: usize) -> Vec<u8> {
+        self.iter
+            .peek_until::<String>(offset)
+            .unwrap_or_default()
+            .into()
     }
 
     /// Récupère les prochains caractères du flux jusqu'à une certaine

--- a/parser/preprocessor.rs
+++ b/parser/preprocessor.rs
@@ -5,6 +5,7 @@
 use std::borrow::Cow;
 
 use infra::{
+    algorithms::Parameter,
     primitive::codepoint::CodePoint,
     structure::lists::{peekable::PeekableInterface, queue::ListQueue},
 };
@@ -75,12 +76,12 @@ where
         self.nth(n)
     }
 
-    // NOTE(phisyx): utiliser un générique pour le second paramètre?
-    pub fn advance_as_long_as(
+    pub fn advance_as_long_as<'a, Limit: Parameter<'a, usize>>(
         &mut self,
         predicate: impl Fn(&I) -> bool,
-        with_limit: Option<usize>,
+        with_limit: Limit,
     ) -> Vec<I> {
+        let with_limit = unsafe { with_limit.param().value() };
         let mut limit = with_limit.map(|n| n + 1).unwrap_or(0);
         let mut result = vec![];
 


### PR DESCRIPTION
- refactor(parser): change le nom de la fonction next_input_char
- feat(css): CSS parser
- CSS Tokenization (#77)
- feat(infra): paramètres
- refactor(css): améliore l'API la fonction advance_as_long_as
