### PR TITLE
CSS: analyse d'une feuille de style

### DIFF
--- a/css/parser/Cargo.toml
+++ b/css/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resworb-css-parser"
-version = "0.1.18"
+version = "0.1.19"
 license-file = "../LICENSE"
 edition = "2021"
 

--- a/css/parser/at_rule.rs
+++ b/css/parser/at_rule.rs
@@ -1,0 +1,41 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use crate::{
+    component_value::CSSComponentValue, simple_block::CSSSimpleBlock,
+    tokenization::CSSToken,
+};
+
+// --------- //
+// Structure //
+// --------- //
+
+/// Une at-rule possède un nom, un prélude constitué d'une liste de
+/// valeurs de composants, et un bloc optionnel constitué d'un simple bloc
+/// {}.
+///
+/// NOTE(css): la plupart des règles qualifiées seront des règles de style,
+/// où le prélude est un sélecteur <https://www.w3.org/TR/selectors-3>
+/// et le bloc une liste de déclarations.
+#[derive(Debug)]
+#[derive(Default)]
+#[derive(PartialEq, Eq)]
+pub struct CSSAtRule {
+    name: String,
+    prelude: Vec<CSSComponentValue>,
+    block: Option<CSSSimpleBlock>,
+}
+
+// -------------- //
+// Implémentation //
+// -------------- //
+
+impl CSSAtRule {
+    pub(crate) fn with_name(mut self, token: &CSSToken) -> Self {
+        if let CSSToken::AtKeyword(name) = token {
+            self.name = name.to_owned();
+        }
+        self
+    }
+}

--- a/css/parser/component_value.rs
+++ b/css/parser/component_value.rs
@@ -1,0 +1,81 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use crate::{
+    function::CSSFunction, preserved_tokens::CSSPreservedToken,
+    simple_block::CSSSimpleBlock, tokenization::CSSToken,
+};
+
+// --------- //
+// Structure //
+// --------- //
+
+/// Une valeur de composant est l'un des [jetons
+/// conservés](CSSPreservedToken), une [fonction](CSSFunction) ou un
+/// [bloc simple](CSSSimpleBlock).
+#[derive(Debug)]
+#[derive(PartialEq, Eq)]
+pub(crate) enum CSSComponentValue {
+    Preserved(CSSPreservedToken),
+    Function(CSSFunction),
+    SimpleBlock(CSSSimpleBlock),
+}
+
+// -------------- //
+// Implémentation // -> Interface
+// -------------- //
+
+impl From<CSSPreservedToken> for CSSComponentValue {
+    fn from(token: CSSPreservedToken) -> Self {
+        Self::Preserved(token)
+    }
+}
+
+impl From<CSSFunction> for CSSComponentValue {
+    fn from(function: CSSFunction) -> Self {
+        Self::Function(function)
+    }
+}
+
+impl From<CSSSimpleBlock> for CSSComponentValue {
+    fn from(simple_block: CSSSimpleBlock) -> Self {
+        Self::SimpleBlock(simple_block)
+    }
+}
+
+impl From<CSSToken> for CSSComponentValue {
+    fn from(token: CSSToken) -> Self {
+        match token {
+            | CSSToken::EOF
+            | CSSToken::Ident(_)
+            | CSSToken::AtKeyword(_)
+            | CSSToken::Hash(_, _)
+            | CSSToken::String(_)
+            | CSSToken::BadString
+            | CSSToken::Url(_)
+            | CSSToken::BadUrl
+            | CSSToken::Delim(_)
+            | CSSToken::Number(_, _)
+            | CSSToken::Percentage(_)
+            | CSSToken::Dimension(_, _, _)
+            | CSSToken::Whitespace
+            | CSSToken::CDO
+            | CSSToken::CDC
+            | CSSToken::Colon
+            | CSSToken::Semicolon
+            | CSSToken::Comma => Self::Preserved(token.into()),
+
+            | CSSToken::Function(_) => Self::Function(token.into()),
+
+            | CSSToken::LeftSquareBracket
+            | CSSToken::RightSquareBracket
+            | CSSToken::LeftParenthesis
+            | CSSToken::RightParenthesis
+            | CSSToken::LeftCurlyBracket
+            | CSSToken::RightCurlyBracket => {
+                Self::SimpleBlock(token.into())
+            }
+        }
+    }
+}

--- a/css/parser/entrypoints/mod.rs
+++ b/css/parser/entrypoints/mod.rs
@@ -1,0 +1,5 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+pub mod stylesheet;

--- a/css/parser/entrypoints/stylesheet.rs
+++ b/css/parser/entrypoints/stylesheet.rs
@@ -1,0 +1,57 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use crate::{grammars::CSSStyleSheet, CSSParser};
+
+impl<T> CSSParser<T> {
+    /// Analyse d'une feuille de style.
+    pub fn stylesheet(&mut self) -> CSSStyleSheet {
+        self.consume_list_of_rules()
+    }
+}
+
+// ---- //
+// Test //
+// ---- //
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        grammars::CSSRule,
+        qualified_rule::CSSQualifiedRule,
+        simple_block::CSSSimpleBlock,
+        tokenization::{CSSToken, HashFlag},
+    };
+
+    #[test]
+    fn test_parse_a_stylesheet() {
+        let input = "#foo { color: red; }";
+        let mut parser: CSSParser<CSSToken> =
+            CSSParser::new(input.chars());
+
+        assert_eq!(
+            parser.stylesheet(),
+            [CSSRule::QualifiedRule(
+                CSSQualifiedRule::default()
+                    .with_prelude([
+                        CSSToken::Hash("foo".into(), HashFlag::ID),
+                        CSSToken::Whitespace
+                    ])
+                    .with_block(
+                        CSSSimpleBlock::new(CSSToken::RightCurlyBracket)
+                            .set_values([
+                                CSSToken::Whitespace,
+                                CSSToken::Ident("color".into()),
+                                CSSToken::Colon,
+                                CSSToken::Whitespace,
+                                CSSToken::Ident("red".into()),
+                                CSSToken::Semicolon,
+                                CSSToken::Whitespace,
+                            ])
+                    )
+            )]
+        );
+    }
+}

--- a/css/parser/function.rs
+++ b/css/parser/function.rs
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use crate::{component_value::CSSComponentValue, tokenization::CSSToken};
+
+// --------- //
+// Structure //
+// --------- //
+
+/// Une fonction possède un nom et une valeur constituée d'une liste
+/// de valeurs de composants.
+#[derive(Debug)]
+#[derive(Default)]
+#[derive(PartialEq, Eq)]
+pub struct CSSFunction {
+    name: String,
+    value: Vec<CSSComponentValue>,
+}
+
+// -------------- //
+// Implémentation //
+// -------------- //
+
+impl CSSFunction {
+    pub(crate) fn new(name: impl ToString) -> Self {
+        Self {
+            name: name.to_string(),
+            ..Default::default()
+        }
+    }
+}
+
+impl CSSFunction {
+    pub(crate) fn append(&mut self, value: CSSComponentValue) {
+        self.value.push(value);
+    }
+}
+
+// -------------- //
+// Implémentation // -> Interface
+// -------------- //
+
+impl From<CSSToken> for CSSFunction {
+    fn from(token: CSSToken) -> Self {
+        match token {
+            | CSSToken::Function(fn_name) => Self::new(fn_name),
+            | _ => panic!("Expected a function token"),
+        }
+    }
+}

--- a/css/parser/grammars.rs
+++ b/css/parser/grammars.rs
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use crate::{at_rule::CSSAtRule, qualified_rule::CSSQualifiedRule};
+
+/// la production `<rule-list>` représente une liste de règles, et ne peut
+/// être utilisée dans les grammaires que comme seule valeur dans un bloc.
+/// Elle indique que le contenu du bloc doit être analysé à l'aide de
+/// l'algorithme consume a list of rules.
+// NOTE(phisyx): peut-être améliorer ce type.
+pub type CSSRuleList = Vec<CSSRule>;
+
+/// la production `<stylesheet>` représente une liste de règles. Elle est
+/// identique à `<rule-list>`, sauf que les blocs qui l'utilisent acceptent
+/// par défaut toutes les règles qui ne sont pas autrement limitées à un
+/// contexte particulier.
+// NOTE(phisyx): peut-être améliorer ce type.
+pub type CSSStyleSheet = CSSRuleList;
+
+// ----------- //
+// Énumération //
+// ----------- //
+
+/// Voir le tableau <https://www.w3.org/TR/css-syntax-3/#declaration-rule-list>
+#[derive(Debug)]
+#[derive(PartialEq, Eq)]
+pub enum CSSRule {
+    QualifiedRule(CSSQualifiedRule),
+    AtRule(CSSAtRule),
+}
+
+// -------------- //
+// Implémentation // -> Interface
+// -------------- //
+
+impl From<CSSQualifiedRule> for CSSRule {
+    fn from(qualified_rule: CSSQualifiedRule) -> Self {
+        Self::QualifiedRule(qualified_rule)
+    }
+}
+
+impl From<CSSAtRule> for CSSRule {
+    fn from(at_rule: CSSAtRule) -> Self {
+        Self::AtRule(at_rule)
+    }
+}

--- a/css/parser/preserved_tokens.rs
+++ b/css/parser/preserved_tokens.rs
@@ -1,0 +1,63 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::ops;
+
+use crate::tokenization::CSSToken;
+
+// ---- //
+// Type //
+// ---- //
+
+/// Tout token produit par le
+/// [tokenizer](crate::tokenization::CSSTokenizer) à l'exception des
+/// <[fonction-token](crate::tokenization::CSSToken::Function)>s,
+/// <[{-token](crate::tokenization::CSSToken::LeftCurlyBracket)>s,
+/// <[(-token](crate::tokenization::CSSToken::LeftParenthesis)>s, et
+/// <[\[-token](crate::tokenization::CSSToken::LeftSquareBracket)>s.
+///
+/// NOTE(css): les jetons non conservés listés ci-dessus sont toujours
+/// consommés dans des objets de plus haut niveau, soit des fonctions ou
+/// des blocs simples, et n'apparaissent donc jamais dans la sortie de
+/// l'analyseur.
+///
+/// NOTE(css): les jetons
+/// <[}-token](crate::tokenization::CSSToken::RightCurlyBracket)>s,
+/// <[(-token](crate::tokenization::CSSToken::RightParenthesis)>s,
+/// <[\[-token](crate::tokenization::CSSToken::RightSquareBracket)>s,
+/// <[bad-string-token](crate::tokenization::CSSToken::BadString)>, et
+/// <[bad-url-token](crate::tokenization::CSSToken::BadUrl)> sont toujours
+/// des erreurs d'analyse, mais ils sont préservés dans le flux de tokens
+/// par cette spécification pour permettre à d'autres spécifications,
+/// telles que Media Queries, de définir une gestion des erreurs plus fine
+/// que le simple abandon d'une déclaration ou d'un bloc entier.
+#[derive(Debug)]
+#[derive(PartialEq, Eq)]
+pub(crate) struct CSSPreservedToken(pub(crate) CSSToken);
+
+// -------------- //
+// Implémentation // -> Interface
+// -------------- //
+
+impl ops::Deref for CSSPreservedToken {
+    type Target = CSSToken;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl From<CSSToken> for CSSPreservedToken {
+    fn from(token: CSSToken) -> Self {
+        match token {
+            | CSSToken::Function(_)
+            | CSSToken::LeftCurlyBracket
+            | CSSToken::LeftParenthesis
+            | CSSToken::LeftSquareBracket => {
+                panic!("CSSPreservedToken::try_from: {:?}", token)
+            }
+            | _ => Self(token),
+        }
+    }
+}

--- a/css/parser/qualified_rule.rs
+++ b/css/parser/qualified_rule.rs
@@ -1,0 +1,60 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use crate::{
+    component_value::CSSComponentValue,
+    simple_block::{CSSSimpleBlock, CURLY_BRACKET_BLOCK},
+    tokenization::CSSToken,
+};
+
+// --------- //
+// Structure //
+// --------- //
+
+/// Une règle qualifiée possède un prélude constitué d'une liste de
+/// valeurs de composants, et un bloc constitué d'un simple bloc {}.
+#[derive(Debug)]
+#[derive(PartialEq, Eq)]
+pub struct CSSQualifiedRule {
+    prelude: Vec<CSSComponentValue>,
+    block: CSSSimpleBlock,
+}
+
+// -------------- //
+// Implémentation //
+// -------------- //
+
+impl CSSQualifiedRule {
+    pub(crate) fn with_prelude(
+        mut self,
+        prelude: impl IntoIterator<Item = CSSToken>,
+    ) -> Self {
+        self.prelude = prelude.into_iter().map(Into::into).collect();
+        self
+    }
+
+    pub(crate) fn with_block(mut self, block: CSSSimpleBlock) -> Self {
+        self.block = block;
+        self
+    }
+}
+
+impl CSSQualifiedRule {
+    pub(crate) fn append(&mut self, value: CSSComponentValue) {
+        self.prelude.push(value);
+    }
+
+    pub(crate) fn set_block(&mut self, block: CSSSimpleBlock) {
+        self.block = block;
+    }
+}
+
+impl Default for CSSQualifiedRule {
+    fn default() -> Self {
+        Self {
+            prelude: Default::default(),
+            block: CURLY_BRACKET_BLOCK,
+        }
+    }
+}

--- a/css/parser/simple_block.rs
+++ b/css/parser/simple_block.rs
@@ -1,0 +1,74 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use crate::{component_value::CSSComponentValue, tokenization::CSSToken};
+
+// --------- //
+// Structure //
+// --------- //
+
+/// Un bloc simple a un jeton associé (soit un
+/// <[\[-token](CSSToken::LeftSquareBracket)>,
+/// <[(-token](CSSToken::LeftParenthesis)>, ou
+/// <[{-token](CSSToken::LeftCurlyBracket)>) et une valeur constituée d'une
+/// liste de [valeurs de composants](CSSComponentValue).
+///
+/// {}-block, []-block, et ()-block font spécifiquement
+/// référence à un bloc simple avec le jeton associé correspondant.
+#[derive(Debug)]
+#[derive(PartialEq, Eq)]
+pub struct CSSSimpleBlock {
+    token: CSSToken,
+    value: Vec<CSSComponentValue>,
+}
+
+pub const CURLY_BRACKET_BLOCK: CSSSimpleBlock = CSSSimpleBlock {
+    token: CSSToken::LeftCurlyBracket,
+    value: vec![],
+};
+
+// -------------- //
+// Implémentation //
+// -------------- //
+
+impl CSSSimpleBlock {
+    pub(crate) fn new(token: CSSToken) -> Self {
+        Self {
+            token,
+            value: vec![],
+        }
+    }
+
+    pub(crate) fn set_values(
+        mut self,
+        value: impl IntoIterator<Item = impl Into<CSSComponentValue>>,
+    ) -> Self {
+        self.value = value.into_iter().map(Into::into).collect();
+        self
+    }
+}
+
+impl CSSSimpleBlock {
+    pub(crate) fn append(&mut self, value: CSSComponentValue) {
+        self.value.push(value);
+    }
+}
+
+// -------------- //
+// Implémentation // -> Interface
+// -------------- //
+
+impl From<CSSToken> for CSSSimpleBlock {
+    fn from(token: CSSToken) -> Self {
+        match token {
+            | token @ (CSSToken::LeftSquareBracket
+            | CSSToken::LeftParenthesis
+            | CSSToken::LeftCurlyBracket
+            | CSSToken::RightSquareBracket
+            | CSSToken::RightParenthesis
+            | CSSToken::RightCurlyBracket) => CSSSimpleBlock::new(token),
+            | _ => panic!("Impossible de convertir le jeton {token:?} en CSSSimpleBlock."),
+        }
+    }
+}

--- a/css/parser/tokenization/token.rs
+++ b/css/parser/tokenization/token.rs
@@ -62,9 +62,9 @@ pub enum CSSToken {
     Whitespace,
 
     /// Suite de points de code "<!--"
-    Cdo,
+    CDO,
     /// Suite de points de code "-->"
-    Cdc,
+    CDC,
 
     /// Caractère ':'
     Colon,
@@ -123,6 +123,30 @@ pub enum NumberFlag {
 // -------------- //
 
 impl CSSToken {
+    /// Variante miroir d'un dès jetons `<(-token>, <[-token>, <{-token>`,
+    ///
+    /// Exemple:
+    /// Pour le jeton `<(-token>`, la variante miroir est `<)-token>`.
+    pub(crate) fn mirror(&self) -> Self {
+        assert!(matches!(
+            self,
+            Self::LeftParenthesis
+                | Self::LeftSquareBracket
+                | Self::LeftCurlyBracket
+        ));
+
+        match self {
+            | Self::LeftParenthesis => Self::RightParenthesis,
+            | Self::LeftSquareBracket => Self::RightSquareBracket,
+            | Self::LeftCurlyBracket => Self::RightCurlyBracket,
+            | _ => {
+                unreachable!("Impossible de faire un miroir de {:?}", self)
+            }
+        }
+    }
+}
+
+impl CSSToken {
     pub(crate) fn append_character(&mut self, ch: CodePoint) {
         match self {
             | Self::Ident(s)
@@ -137,7 +161,7 @@ impl CSSToken {
 }
 
 impl DimensionUnit {
-    pub fn new(unit: String) -> Self {
+    pub(crate) fn new(unit: String) -> Self {
         Self(unit)
     }
 }

--- a/html/parser/lib.rs
+++ b/html/parser/lib.rs
@@ -2,11 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-#![feature(
-    explicit_generic_args_with_impl_trait,
-    type_name_of_val,
-    option_result_contains
-)]
+#![feature(type_name_of_val, option_result_contains)]
 
 mod codepoint;
 mod error;


### PR DESCRIPTION
- feat(infra): paramètres
- refactor(css): améliore l'API la fonction advance_as_long_as
- chore: applique la commande cargo fmt
- refactor(parser): améliore l'API du flux.
- chore(infra): retrait de code inutile
- refactor(infra): rollback function
- feat(css): analyse d'une feuille de style #80
